### PR TITLE
disable logging of diff

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -81,7 +81,7 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         bnNew = bnPowLimit;
     }
 
-    LogPrintf("--- diff --- %d: %d\n", pindexLast->nHeight, bnNew.GetCompact());
+//    LogPrintf("--- diff --- %d: %d\n", pindexLast->nHeight, bnNew.GetCompact());
 
     return bnNew.GetCompact();
 }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -112,7 +112,7 @@ void AskPassphraseDialog::accept()
             break;
         }
         QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm wallet encryption"),
-                 tr("Warning: If you encrypt your wallet and lose your passphrase, you will <b>LOSE ALL OF YOUR RAVENS</b>!") + "<br><br>" + tr("Are you sure you wish to encrypt your wallet?"),
+                 tr("Warning: If you encrypt your wallet and lose your passphrase, you will <b>LOSE ALL OF YOUR AVN</b>!") + "<br><br>" + tr("Are you sure you wish to encrypt your wallet?"),
                  QMessageBox::Yes|QMessageBox::Cancel,
                  QMessageBox::Cancel);
         if(retval == QMessageBox::Yes)


### PR DESCRIPTION
Disable logging of diff to debug.log.
Filling the log with all this makes debugging other issues harder.
Can be re-enabled easily if necessary.

Example from debug.log: 
![image](https://user-images.githubusercontent.com/26197922/146223899-96336609-3bc0-4d2e-a4a9-1dac2415aa02.png)

