### PR TITLE
GUI: Enable High DPI Scaling

### DIFF
--- a/src/qt/darkstyle.cpp
+++ b/src/qt/darkstyle.cpp
@@ -72,11 +72,11 @@ void DarkStyle::polish(QApplication *app)
 {
   if (!app) return;
 
-  // increase font size for better reading,
-  // setPointSize was reduced from +2 because when applied this way in Qt5, the font is larger than intended for some reason
-  QFont defaultFont = QApplication::font();
-  defaultFont.setPointSize(defaultFont.pointSize()+1);
-  app->setFont(defaultFont);
+// increase font size for better reading,
+// setPointSize was reduced from +2 because when applied this way in Qt5, the font is larger than intended for some reason
+//  QFont defaultFont = QApplication::font();
+//  defaultFont.setPointSize(defaultFont.pointSize()+1);
+//  app->setFont(defaultFont);
 
   // loadstylesheet
   QFile qfDarkstyle(QStringLiteral(":/darkstyle/qss"));

--- a/src/qt/raven.cpp
+++ b/src/qt/raven.cpp
@@ -577,7 +577,6 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(raven);
     Q_INIT_RESOURCE(raven_locale);
 
-    RavenApplication app;
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -589,6 +588,10 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
 #if QT_VERSION >= 0x050500
+
+    // This should be after the attributes.
+    RavenApplication app;
+
     // Because of the POODLE attack it is recommended to disable SSLv3 (https://disablessl3.com/),
     // so set SSL protocols to TLS1.0+.
     QSslConfiguration sslconf = QSslConfiguration::defaultConfiguration();


### PR DESCRIPTION
Set attributes before invoking the application.
This way, they work.

Disable increased font-size in dark-mode.