### PR TITLE
Fix regression test in 4.1

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -350,7 +350,7 @@ public:
 
         genesis = CreateGenesisBlock(1630065295, 24922064, 0x1e00ffff, 4, 10 * COIN);
 
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetX16RHash();
         assert(consensus.hashGenesisBlock == uint256S("0x00000084af22998d2aed78cc29f1fa587f854150ccd2991dfc82241c8f049219"));
         assert(genesis.hashMerkleRoot == uint256S("0x63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -461,19 +461,19 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CROW].nTimeout = 999999999999ULL;
 
         // Crow Algo consensus
-        consensus.powForkTime = 1;                 // Time of PoW hash method change
+        consensus.powForkTime = 1629951212;        // Time of PoW hash method change
         consensus.lwmaAveragingWindow = 45;        // Averaging window size for LWMA diff adjust
-        consensus.diffRetargetFix = 1;             // Block of diff algo change
-        consensus.diffRetargetTake2 = 1;           // Third iteration of LWMA retarget activation timestamp
+        consensus.diffRetargetFix = 0;             // Block of diff algo change
+        consensus.diffRetargetTake2 = 1629951212;  // Third iteration of LWMA retarget activation timestamp
 
         // regtest x16rt switch (genesis +1)
         consensus.nX16rtTimestamp = 1629951212;
 
         // Avian Assets
-        consensus.nAssetActivationTime = 1;
+        consensus.nAssetActivationTime = 1629951212;
 
         // Avian Flight Plans
-        consensus.nFlightPlansActivationTime = 1;
+        consensus.nFlightPlansActivationTime = 1629951212;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
@@ -504,7 +504,7 @@ public:
         for (int i=0;i<40000000;i++) {
             genesis = CreateGenesisBlock(1629951211, i, 0x207fffff, 2, 2500 * COIN);
             //genesis.hashPrevBlock = TempHashHolding;
-            consensus.hashGenesisBlock = genesis.GetX16RHash();
+            consensus.hashGenesisBlock = genesis.GetHash();
 
             arith_uint256 BestBlockHashArith = UintToArith256(BestBlockHash);
             if (UintToArith256(consensus.hashGenesisBlock) < BestBlockHashArith) {
@@ -549,11 +549,11 @@ public:
 //        /////////////////////////////////////////////////////////////////
 
 
-        genesis = CreateGenesisBlock(1629951211, 1, 0x207fffff, 4, 2500 * COIN);
-        consensus.hashGenesisBlock = genesis.GetX16RHash();
-
-        assert(consensus.hashGenesisBlock == uint256S("0x0d2d32f6d3fa3d0eb49602b7ea50eb684ada6dd5b411b1e5dbf6687c520dd9b1"));
-        assert(genesis.hashMerkleRoot == uint256S("3f3621f5a83a2697099fea380f24f2854e15c912828a09112942d543033bcbf8"));
+        genesis = CreateGenesisBlock(1629951211, 1, 0x207fffff, 2, 2500 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        
+        assert(consensus.hashGenesisBlock == uint256S("0x653634d03d27ed84e8aba5dd47903906ad7be4876a1d3677be0db2891dcf787f"));
+        assert(genesis.hashMerkleRoot == uint256S("63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
@@ -561,6 +561,7 @@ public:
         fDefaultConsistencyChecks = true;
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
+        fMiningRequiresPeers = false;
 
         checkpointData = (CCheckpointData) {
             {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -466,6 +466,9 @@ public:
         consensus.diffRetargetFix = 0;             // Block of diff algo change
         consensus.diffRetargetTake2 = 1629951212;  // Third iteration of LWMA retarget activation timestamp
 
+        consensus.powTypeLimits.emplace_back(uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));   // x16rt limit
+        consensus.powTypeLimits.emplace_back(uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));   // Crow limit
+
         // regtest x16rt switch (genesis +1)
         consensus.nX16rtTimestamp = 1629951212;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -193,7 +193,7 @@ public:
 
         genesis = CreateGenesisBlock(1630067829, 8650489, 0x1e00ffff, 4, 10 * COIN);
 
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetX16RHash();
         assert(consensus.hashGenesisBlock == uint256S("0x000000cdb10fc01df7fba251f2168ef7cd7854b571049db4902c315694461dd0"));
         assert(genesis.hashMerkleRoot == uint256S("0x63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 
@@ -550,8 +550,8 @@ public:
 
 
         genesis = CreateGenesisBlock(1629951211, 1, 0x207fffff, 2, 2500 * COIN);
+
         consensus.hashGenesisBlock = genesis.GetHash();
-        
         assert(consensus.hashGenesisBlock == uint256S("0x653634d03d27ed84e8aba5dd47903906ad7be4876a1d3677be0db2891dcf787f"));
         assert(genesis.hashMerkleRoot == uint256S("63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -29,6 +29,7 @@ static const uint32_t REGTEST_X16RT_ACTIVATIONTIME = 1629951212;
 
 static const uint32_t MAINNET_CROW_MULTI_ACTIVATIONTIME = 1638847407;
 static const uint32_t TESTNET_CROW_MULTI_ACTIVATIONTIME = 1639005225;
+static const uint32_t REGTEST_CROW_MULTI_ACTIVATIONTIME = 1629951212;
 
 BlockNetwork bNetwork = BlockNetwork();
 
@@ -54,11 +55,12 @@ uint256 CBlockHeader::GetHash() const
     uint32_t nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
     uint32_t nCrowTimeToUse = MAINNET_CROW_MULTI_ACTIVATIONTIME;
 
-    if (bNetwork.fOnTestnet){
+    if (bNetwork.fOnTestnet) {
         nTimeToUse = TESTNET_X16RT_ACTIVATIONTIME;
         nCrowTimeToUse = TESTNET_CROW_MULTI_ACTIVATIONTIME;
     } else if (bNetwork.fOnRegtest) {
         nTimeToUse = REGTEST_X16RT_ACTIVATIONTIME;
+        nCrowTimeToUse = REGTEST_CROW_MULTI_ACTIVATIONTIME;
     } else {
         nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
         nCrowTimeToUse = MAINNET_CROW_MULTI_ACTIVATIONTIME;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -90,11 +90,18 @@ SplashScreen::SplashScreen(const NetworkStyle* networkStyle)
         gradient.setColorAt(1, QColor(42, 115, 127));
         QRect rGradient(QPoint(0, 0), splashSize);
         pixPaint.fillRect(rGradient, gradient);
-    } else {
+    } else if(titleAddText == QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")) {
         // Testnet
         QRadialGradient gradient(QPoint(0, 0), splashSize.width() / devicePixelRatio);
         gradient.setColorAt(0, QColor(68, 73, 205));
         gradient.setColorAt(1, QColor(31, 22, 142));
+        QRect rGradient(QPoint(0, 0), splashSize);
+        pixPaint.fillRect(rGradient, gradient);
+    } else if(titleAddText == "[regtest]") {
+        // Regtest
+        QRadialGradient gradient(QPoint(0, 0), splashSize.width() / devicePixelRatio);
+        gradient.setColorAt(0, QColor(255, 41, 41));
+        gradient.setColorAt(1, QColor(255, 115, 115));
         QRect rGradient(QPoint(0, 0), splashSize);
         pixPaint.fillRect(rGradient, gradient);
     }


### PR DESCRIPTION
This PR allows `regtest` or regression test to run without any assert fails. This is important to merge *urgently* since it is a blocker PR to enable our testing framework for it to work properly.  Mainnet and Testnet work fine without any assert fails.

![image](https://user-images.githubusercontent.com/36016500/178635477-1420690b-7c85-4e48-abe2-b78377446c82.png)
