### PR TITLE
lua: Use POSIX mkstemp instead of tmpnam

### DIFF
--- a/src/lua/loslib.c
+++ b/src/lua/loslib.c
@@ -110,8 +110,6 @@
 */
 #if !defined(lua_tmpnam)	/* { */
 
-#if defined(LUA_USE_POSIX)	/* { */
-
 #include <unistd.h>
 
 #define LUA_TMPNAMBUFSIZE	32
@@ -129,12 +127,11 @@
 #else				/* }{ */
 
 /* ISO C definitions */
-#define LUA_TMPNAMBUFSIZE	L_tmpnam
-#define lua_tmpnam(b,e)		{ e = (tmpnam(b) == NULL); }
+// #define LUA_TMPNAMBUFSIZE	L_tmpnam
+// #define lua_tmpnam(b,e)		{ e = (tmpnam(b) == NULL); }
 
 #endif				/* } */
 
-#endif				/* } */
 /* }================================================================== */
 
 


### PR DESCRIPTION
This fixes a error messaging when linking avian during the build process:
```bash
warning: the use of 'tmpnam' is dangerous, better use 'mkstemp'
```

Our targets (Linux, Mingw-w64, Darwin) support POSIX standards. The Microsoft Visual C++  Compiler (MSVC) does not support POSIX `mkstemp`; however, using the Mingw-w64 (gcc) compiler supports POSIX `mkstemp`. The CI/CD should verify if a windows binary is built successfully. (since it uses mingw-w64).

Loosing support for MSVC can be addressed in a different issue or PR if it becomes a problem in the future.
