### PR TITLE
Qt: Improve peer tab

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -889,11 +889,17 @@
            <property name="tabKeyNavigation">
             <bool>false</bool>
            </property>
+           <property name="textElideMode">
+            <enum>Qt::ElideMiddle</enum>
+           </property>
            <property name="alternatingRowColors">
             <bool>true</bool>
            </property>
            <property name="sortingEnabled">
             <bool>true</bool>
+           </property>
+           <property name="wordWrap">
+              <bool>false</bool>
            </property>
            <attribute name="horizontalHeaderHighlightSections">
             <bool>false</bool>

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -29,6 +29,8 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
         return pLeft->nodeid < pRight->nodeid;
     case PeerTableModel::Address:
         return pLeft->addrName.compare(pRight->addrName) < 0;
+    case PeerTableModel::Direction:
+        return pLeft->fInbound > pRight->fInbound; // default sort Inbound, then Outbound
     case PeerTableModel::Subversion:
         return pLeft->cleanSubVer.compare(pRight->cleanSubVer) < 0;
     case PeerTableModel::Ping:
@@ -117,7 +119,7 @@ PeerTableModel::PeerTableModel(ClientModel *parent) :
     clientModel(parent),
     timer(0)
 {
-    columns << tr("NodeId") << tr("Node/Service") << tr("Ping") << tr("Sent") << tr("Received") << tr("User Agent");
+    columns << tr("NodeId") << tr("Node/Service") <<  tr("Direction") << tr("Ping") << tr("Sent") << tr("Received") << tr("User Agent");
     priv.reset(new PeerTablePriv());
     // default to unsorted
     priv->sortColumn = -1;
@@ -171,7 +173,10 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case NetNodeId:
             return (qint64)rec->nodeStats.nodeid;
         case Address:
-            return QString::fromStdString(rec->nodeStats.addrName);
+            // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
+            return QString::fromStdString((rec->nodeStats.fInbound ? "↓ " : "↑ ") + rec->nodeStats.addrName);
+        case Direction:
+            return QString(rec->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
         case Subversion:
             return QString::fromStdString(rec->nodeStats.cleanSubVer);
         case Ping:
@@ -188,6 +193,8 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case Sent:
         case Received:
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
+        case Direction:
+            return QVariant(Qt::AlignCenter);
         default: return QVariant();
         }
     }

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -56,10 +56,11 @@ public:
     enum ColumnIndex {
         NetNodeId = 0,
         Address = 1,
-        Ping = 2,
-        Sent = 3,
-        Received = 4,
-        Subversion = 5
+        Direction = 2,
+        Ping = 3,
+        Sent = 4,
+        Received = 5,
+        Subversion = 6
     };
 
     /** @name Methods overridden from QAbstractTableModel

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -582,6 +582,11 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         // create peer table context menu
         peersTableContextMenu = new QMenu(this);
+        //: Context menu action to copy the address of a peer
+        peersTableContextMenu->addAction(tr("&Copy address"), [this] {
+            GUIUtil::copyEntryData(ui->peerWidget, PeerTableModel::Address, Qt::DisplayRole);
+        });
+        peersTableContextMenu->addSeparator();
         peersTableContextMenu->addAction(disconnectAction);
         peersTableContextMenu->addAction(banAction1h);
         peersTableContextMenu->addAction(banAction24h);


### PR DESCRIPTION
This PR improves the peer tab by adding:

- Direction column and icon showing if a peer is inbound or outbound.
- "Copy address" to context menu when right-clicking a peer.
- Elide long strings in their middle in peers tab

These changes were back-ported from Bitcoin and tested to work. If there is more peer tab changes from Bitcoin we can backport, feel free to open a PR or comment here.

 
![Screenshot from 2022-07-12 23-23-30](https://user-images.githubusercontent.com/36016500/178644780-9a897aa3-7b7d-480e-a1ec-05a84da35f17.png)
