### PR TITLE
Qt: Use common gradient for assets in overview page

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -209,23 +209,8 @@ public:
         QLinearGradient gradient(mainRect.topLeft(), mainRect.bottomRight());
 
         // Select the color of the gradient
-        if (admin) {
-            //if (darkModeEnabled) {
-            //    gradient.setColorAt(0, COLOR_ADMIN_CARD_DARK);
-            //    gradient.setColorAt(1, COLOR_ADMIN_CARD_DARK);
-            //} else {
-                gradient.setColorAt(0, COLOR_AVIAN_19827B);
-                gradient.setColorAt(1, COLOR_AVIAN_18A7B7);
-           // }
-        } else {
-            //if (darkModeEnabled) {
-            //    gradient.setColorAt(0, COLOR_REGULAR_CARD_LIGHT_BLUE_DARK_MODE);
-            //    gradient.setColorAt(1, COLOR_REGULAR_CARD_DARK_BLUE_DARK_MODE);
-            //} else {
-                gradient.setColorAt(0, COLOR_AVIAN_2B737F);
-                gradient.setColorAt(1, COLOR_AVIAN_34E2D6);
-            //}
-        }
+        gradient.setColorAt(0, COLOR_AVIAN_19827B);
+        gradient.setColorAt(1, COLOR_AVIAN_18A7B7);
 
         // Using 4 are the radius because the pixels are solid
         QPainterPath path;


### PR DESCRIPTION
This PR forces the asset background (in overview page) to be same color regardless if it's admin. An icon is already shown if the asset is admin.

Would like thoughts on this change.

![image](https://user-images.githubusercontent.com/36016500/178645075-a002a07f-0a24-493d-ba77-ea1fa8b97efd.png)
