### PR TITLE
Introduce proper AreMessagesDeployed() and AreRestrictedAssetsDeployed()

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -157,8 +157,10 @@ public:
         // x16rt switch
         consensus.nX16rtTimestamp = 1638748799;
 
-        // Avian Assets
+        // Avian Assets, Messaging, Restricted
         consensus.nAssetActivationTime = 999999999999ULL; // TODO
+        consensus.nMessagingActivationTime = 999999999999ULL; // TODO
+        consensus.nRestrictedActivationTime = 999999999999ULL; // TODO
 
         // Avian Flight Plans
         consensus.nFlightPlansActivationTime = 999999999999ULL; // TODO
@@ -275,9 +277,6 @@ public:
 
         // TODO: Assets, Messaging, Restricted
         nAssetActivationHeight = 9999999999; // Asset activated block height
-        nMessagingActivationBlock = 9999999999; // Messaging activated block height
-        nRestrictedActivationBlock = 9999999999; // Restricted activated block height
-
         /** AVN End **/
     }
 };
@@ -329,6 +328,11 @@ public:
 
         // Avian Assets
         consensus.nAssetActivationTime = 1645104453; // Feb 17, 2022
+
+        // Avian Assets, Messaging, Restricted
+        consensus.nAssetActivationTime = 1645104453; // Feb 17, 2022
+        consensus.nMessagingActivationTime = 1645104453; // Feb 17, 2022
+        consensus.nRestrictedActivationTime = 1645104453; // Feb 17, 2022
 
         // Avian Flight Plans
         consensus.nFlightPlansActivationTime = 1645104453; // Feb 17, 2022
@@ -420,9 +424,7 @@ public:
         nMinReorganizationPeers = 4;
         nMinReorganizationAge = 60 * 60 * 12; // 12 hours
 
-        nAssetActivationHeight = 0; // Asset activated block height
-        nMessagingActivationBlock = 0; // Messaging activated block height
-        nRestrictedActivationBlock = 0; // Restricted activated block height
+        nAssetActivationHeight = 1; // Asset activated block height
         /** AVN End **/
     }
 };
@@ -473,6 +475,11 @@ public:
 
         // Avian Assets
         consensus.nAssetActivationTime = 1629951212;
+
+        // Avian Assets, Messaging, Restricted
+        consensus.nAssetActivationTime = 1629951212; // (genesis +1)
+        consensus.nMessagingActivationTime = 1629951212; // (genesis +1)
+        consensus.nRestrictedActivationTime = 1629951212; // (genesis +1)
 
         // Avian Flight Plans
         consensus.nFlightPlansActivationTime = 1629951212;
@@ -618,9 +625,7 @@ public:
         nMinReorganizationPeers = 4;
         nMinReorganizationAge = 60 * 60 * 12; // 12 hours
 
-        nAssetActivationHeight = 0; // Asset activated block height
-        nMessagingActivationBlock = 0; // Messaging activated block height
-        nRestrictedActivationBlock = 0; // Restricted activated block height
+        nAssetActivationHeight = 1; // Asset activated block height
         /** AVN End **/
     }
 };

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -135,8 +135,6 @@ public:
     }
 
     unsigned int DGWActivationBlock() const { return nDGWActivationBlock; }
-    unsigned int MessagingActivationBlock() const { return nMessagingActivationBlock; }
-    unsigned int RestrictedActivationBlock() const { return nRestrictedActivationBlock; }
 
     int MaxReorganizationDepth() const { return nMaxReorganizationDepth; }
     int MinReorganizationPeers() const { return nMinReorganizationPeers; }
@@ -192,8 +190,6 @@ protected:
     std::string strGlobalBurnAddress;
 
     unsigned int nDGWActivationBlock;
-    unsigned int nMessagingActivationBlock;
-    unsigned int nRestrictedActivationBlock;
     uint32_t nX16RV2ActivationTime;
 
     int nMaxReorganizationDepth;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -42,7 +42,6 @@ static const size_t MIN_SERIALIZABLE_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR *
 //! it causes unused variable warnings when compiling. This UNUSED_VAR removes the unused warnings
 UNUSED_VAR static bool fAssetsIsActive = false;
 UNUSED_VAR static bool fFlightPlansIsActive = false;
-UNUSED_VAR static bool fRip5IsActive = false;
 UNUSED_VAR static bool fTransferScriptIsActive = false;
 UNUSED_VAR static bool fEnforcedValuesIsActive = false;
 UNUSED_VAR static bool fCheckCoinbaseAssetsIsActive = false;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -83,6 +83,12 @@ struct ConsensusParams {
     // AVN Assets
     uint32_t nAssetActivationTime;
 
+    // Messaging
+    uint32_t nMessagingActivationTime;
+
+    // Restricted
+    uint32_t nRestrictedActivationTime;
+
     // AVN Flight Plans
     uint32_t nFlightPlansActivationTime;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1613,12 +1613,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                               passetsCache->Size());
 
                     // Check for changed -disablemessaging state
-                    // TODO: Change to !AreMessagesDeployed()
-                    if (!bNetwork.fOnTestnet || gArgs.GetArg("-disablemessaging", false)) {
+                    if (gArgs.GetBoolArg("-disablemessaging", false)) {
                         LogPrintf("Messaging is disabled\n");
                         fMessaging = false;
                     } else {
-                        fMessaging = true;
+                        // TODO: This can be misleading.
                         LogPrintf("Messaging is enabled\n");
                     }
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -94,6 +94,7 @@ int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fMessaging = false;
+bool fRestricted = false;
 bool fTxIndex = false;
 bool fAssetIndex = false;
 bool fAddressIndex = false;
@@ -5892,21 +5893,24 @@ bool AreFlightPlansDeployed()
     return fFlightPlansIsActive;
 }
 
-bool IsRip5Active()
-{
-    if (fRip5IsActive)
+bool AreMessagesDeployed() {
+    if (fMessaging)
         return true;
 
-    // TODO: Fix
-    // const ThresholdState thresholdState = VersionBitsTipState(Params().GetConsensus(), Consensus::DEPLOYMENT_MSG_REST_ASSETS);
-    // if (thresholdState == THRESHOLD_ACTIVE)
-    //     fRip5IsActive = true;
+    if ((chainActive.Tip() != nullptr) && chainActive.Tip()->nTime > Params().GetConsensus().nMessagingActivationTime)
+        fMessaging = true;
 
-    return false;
+    return fMessaging;
 }
 
-bool AreMessagesDeployed() {
-    return IsRip5Active();
+bool AreRestrictedAssetsDeployed() {
+    if (fRestricted)
+        return true;
+
+    if ((chainActive.Tip() != nullptr) && chainActive.Tip()->nTime > Params().GetConsensus().nRestrictedActivationTime)
+        fRestricted = true;
+
+    return fRestricted;
 }
 
 bool AreTransferScriptsSizeDeployed() {
@@ -5922,30 +5926,8 @@ bool AreTransferScriptsSizeDeployed() {
     return false;
 }
 
-bool AreRestrictedAssetsDeployed() {
-
-    return IsRip5Active();
-}
-
 bool IsDGWActive(unsigned int nBlockNumber) {
     return nBlockNumber >= Params().DGWActivationBlock();
-}
-
-bool IsMessagingActive(unsigned int nBlockNumber) {
-    if (Params().MessagingActivationBlock()) {
-        return nBlockNumber > Params().MessagingActivationBlock();
-    } else {
-        return AreMessagesDeployed();
-    }
-}
-
-bool IsRestrictedActive(unsigned int nBlockNumber)
-{
-    if (Params().RestrictedActivationBlock()) {
-        return nBlockNumber > Params().RestrictedActivationBlock();
-    } else {
-        return AreRestrictedAssetsDeployed();
-    }
 }
 
 CAssetsCache* GetCurrentAssetCache()

--- a/src/validation.h
+++ b/src/validation.h
@@ -199,6 +199,7 @@ extern CConditionVariable cvBlockChange;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 extern bool fMessaging;
+extern bool fRestricted;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fAssetIndex;
@@ -616,14 +617,9 @@ bool AreCoinbaseCheckAssetsDeployed();
 void SetEnforcedValues(bool value);
 void SetEnforcedCoinbase(bool value);
 
-bool IsRip5Active();
-
-
 bool AreTransferScriptsSizeDeployed();
 
 bool IsDGWActive(unsigned int nBlockNumber);
-bool IsMessagingActive(unsigned int nBlockNumber);
-bool IsRestrictedActive(unsigned int nBlockNumber);
 
 CAssetsCache* GetCurrentAssetCache();
 /** AVN END */


### PR DESCRIPTION
This PR adds working:
`AreMessagesDeployed()`
`AreRestrictedAssetsDeployed()`

This PR also converts the respective chain params from block height to a timestamp for consistency.

During my testing, message was correctly enabled and disabled on mainnet, testnet, and regtest.

However, the message below can be misleading and I have put a *TODO* to fix it later. *(issue more complex them it seems and more testing required which is out of scope of this PR).*  This should not effect the actual `AreMessagesDeployed()` from providing correct boolean values.

https://github.com/AvianNetwork/Avian/blob/5aa0e4aa4040c1f3f1f71b0aa1a6edf2e86875d2/src/init.cpp#L1622
