### PR TITLE
Use ConsenusParams in BlockHeader for GetHash() (Dual algo)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -155,7 +155,7 @@ public:
         consensus.powTypeLimits.emplace_back(uint256S("000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));   // Crow limit
 
         // x16rt switch
-        consensus.nX16rtTimestamp = 1638748799;
+        consensus.nX16rtTimestamp = 1638847406;
 
         // Avian Assets
         consensus.nAssetActivationTime = 999999999999ULL; // TODO
@@ -553,7 +553,7 @@ public:
 
         genesis = CreateGenesisBlock(1629951211, 1, 0x207fffff, 2, 2500 * COIN);
 
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetX16RHash();
         assert(consensus.hashGenesisBlock == uint256S("0x653634d03d27ed84e8aba5dd47903906ad7be4876a1d3677be0db2891dcf787f"));
         assert(genesis.hashMerkleRoot == uint256S("63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -128,7 +128,7 @@ bool IsTransitioningToX16rt(const CBlockIndex* pindexLast, const CBlockHeader *p
     if (pblock->nTime <= params.nX16rtTimestamp)
         return false;
         
-    int64_t dgwWindow = 0; // RVL does not have DGWPastBlocks so no need to check.
+    int64_t dgwWindow = 0; // AVN does not have DGWPastBlocks so no need to check.
 
     const CBlockIndex* pindex = pindexLast;
     

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -1,35 +1,22 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
 // Copyright (c) 2017 The Raven Core developers
+// Copyright (c) 2022 The Avian Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#include "versionbits.h"
-
-#include <cstdint>
-
-#include "chainparams.h"
-
-#include "algo/crow/minotaurx.h"             // Minotaurx Algo
 
 #include "primitives/block.h"
 
 #include "algo/hash_algos.h"
+#include "versionbits.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 #include "crypto/common.h"
+#include "chainparams.h"
 
-#include "consensus/consensus.h"
+#include "algo/crow/minotaurx.h"    // Minotaurx Algo
 
 #define TIME_MASK 0xffffff80
-
-static const uint32_t MAINNET_X16RT_ACTIVATIONTIME = 1638847406;
-static const uint32_t TESTNET_X16RT_ACTIVATIONTIME = 1634101200;
-static const uint32_t REGTEST_X16RT_ACTIVATIONTIME = 1629951212;
-
-static const uint32_t MAINNET_CROW_MULTI_ACTIVATIONTIME = 1638847407;
-static const uint32_t TESTNET_CROW_MULTI_ACTIVATIONTIME = 1639005225;
-static const uint32_t REGTEST_CROW_MULTI_ACTIVATIONTIME = 1629951212;
 
 BlockNetwork bNetwork = BlockNetwork();
 
@@ -52,40 +39,29 @@ uint256 CBlockHeader::GetHash() const
 {
     uint256 thash;
     unsigned int profile = 0x0;
-    uint32_t nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
-    uint32_t nCrowTimeToUse = MAINNET_CROW_MULTI_ACTIVATIONTIME;
+    uint32_t nX16rtTimestamp = Params().GetConsensus().nX16rtTimestamp;
+    uint32_t nCrowTimestamp = Params().GetConsensus().powForkTime;
 
-    if (bNetwork.fOnTestnet) {
-        nTimeToUse = TESTNET_X16RT_ACTIVATIONTIME;
-        nCrowTimeToUse = TESTNET_CROW_MULTI_ACTIVATIONTIME;
-    } else if (bNetwork.fOnRegtest) {
-        nTimeToUse = REGTEST_X16RT_ACTIVATIONTIME;
-        nCrowTimeToUse = REGTEST_CROW_MULTI_ACTIVATIONTIME;
-    } else {
-        nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
-        nCrowTimeToUse = MAINNET_CROW_MULTI_ACTIVATIONTIME;
-    }
-
-    if (nTime > nTimeToUse) {
-        if(nTime > nCrowTimeToUse) {
+    if (nTime > nX16rtTimestamp) {
+        if(nTime > nCrowTimestamp) {
             // Mutli algo (x16rt + new Crow algo)
             switch (GetPoWType()) {
-            case POW_TYPE_X16RT: {
-                int32_t nTimeX16r = nTime & TIME_MASK;
-                uint256 hashTime = Hash(BEGIN(nTimeX16r), END(nTimeX16r));
-                thash = HashX16R(BEGIN(nVersion), END(nNonce), hashTime);
-                break;
-            }
-            case POW_TYPE_CROW: {
-                return Minotaurx(BEGIN(nVersion), END(nNonce), true);
-                break;
-            }
-            default: // Don't crash the client on invalid blockType, just return a bad hash
-                return HIGH_HASH;
+                case POW_TYPE_X16RT: {
+                    int32_t nTimeX16r = nTime & TIME_MASK;
+                    uint256 hashTime = Hash(BEGIN(nTimeX16r), END(nTimeX16r));
+                    thash = HashX16R(BEGIN(nVersion), END(nNonce), hashTime);
+                    break;
+                }
+                case POW_TYPE_CROW: {
+                    return Minotaurx(BEGIN(nVersion), END(nNonce), true);
+                    break;
+                }
+                default: // Don't crash the client on invalid blockType, just return a bad hash
+                    return HIGH_HASH;
             }
         } else {
             // x16rt before dual-algo
-            int32_t nTimeX16r = nTime&TIME_MASK;
+            int32_t nTimeX16r = nTime & TIME_MASK;
             uint256 hashTime = Hash(BEGIN(nTimeX16r), END(nTimeX16r));
             thash = HashX16R(BEGIN(nVersion), END(nNonce), hashTime);
         }


### PR DESCRIPTION
This replaces the hard-coded timestamps in `block.cpp` with the correct Params() timestamp. This commit also changes regtest to use GetX16RHash() since the first block uses X16R and not the dual-algo system.

*Note: The X16RT timestamp in chainparams was updated to use the correct one used in the actual mainnet.*

Mainnet, Testnet, and Regtest were tested and worked without issue.