### PR TITLE
Uses SHA-256 hash of block-index object instead of CPU-heavy PoW hash (draft)

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -297,6 +297,11 @@ public:
         return *phashBlock;
     }
 
+    uint256 GetBlockPoWHash() const
+    {
+        return GetBlockHeader().GetPoWHash();
+    }
+
     int64_t GetBlockTime() const
     {
         return (int64_t)nTime;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -553,7 +553,7 @@ public:
 
         genesis = CreateGenesisBlock(1629951211, 1, 0x207fffff, 2, 2500 * COIN);
 
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetPoWHash();
         assert(consensus.hashGenesisBlock == uint256S("0x653634d03d27ed84e8aba5dd47903906ad7be4876a1d3677be0db2891dcf787f"));
         assert(genesis.hashMerkleRoot == uint256S("63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -491,7 +491,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Consens
 bool CheckProofOfWork(const CBlockHeader& blockheader, const Consensus::ConsensusParams& params)
 {
 	if (blockheader.GetBlockTime() > params.diffRetargetTake2)
-		return CheckProofOfWorkCrow(blockheader.GetHash(), blockheader.nBits, params, blockheader.GetPoWType());
+		return CheckProofOfWorkCrow(blockheader.GetPoWHash(), blockheader.nBits, params, blockheader.GetPoWType());
 	else
-		return CheckProofOfWork(blockheader.GetHash(), blockheader.nBits, params);
+		return CheckProofOfWork(blockheader.GetPoWHash(), blockheader.nBits, params);
 }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -50,6 +50,11 @@ void BlockNetwork::SetNetwork(const std::string& net)
 
 uint256 CBlockHeader::GetHash() const
 {
+    return SerializeHash(*this);
+}
+
+uint256 CBlockHeader::GetPoWHash() const
+{
     uint256 thash;
     unsigned int profile = 0x0;
     uint32_t nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
@@ -111,8 +116,9 @@ uint256 CBlockHeader::GetX16RHash() const
 std::string CBlock::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    s << strprintf("CBlock(hash=%s, powHash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
+        GetPoWHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -96,6 +96,7 @@ public:
     }
 
     uint256 GetHash() const;
+    uint256 GetPoWHash() const;
     uint256 GetX16RHash() const;
 
     // Crow: MinotaurX


### PR DESCRIPTION
Work-in-progess: **DO NOT MERGE**

This PR should speed up wallet loading times. Maybe not be included in 4.1.