### PR TITLE
Add backward compatibility with ReadAddressUnspentIndex

### DIFF
--- a/src/algo/sph_sha2.h
+++ b/src/algo/sph_sha2.h
@@ -37,8 +37,8 @@
  * @author   Thomas Pornin <thomas.pornin@cryptolog.com>
  */
 
-#ifndef RVL_POW_SPH_SHA2_H
-#define RVL_POW_SPH_SHA2_H
+#ifndef AVN_POW_SPH_SHA2_H
+#define AVN_POW_SPH_SHA2_H
 
 #include <stddef.h>
 #include "sph_types.h"
@@ -375,4 +375,4 @@ void sph_sha512_comp(const sph_u64 msg[16], sph_u64 val[8]);
 #ifdef __cplusplus
 }
 #endif
-#endif // RVL_POW_SPH_SHA2_H
+#endif // AVN_POW_SPH_SHA2_H

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -76,7 +76,7 @@ static const std::regex QUALIFIER_INDICATOR("^[#][A-Z0-9._]{3,}$"); // Starts wi
 static const std::regex SUB_QUALIFIER_INDICATOR("^#[A-Z0-9._]+\\/#[A-Z0-9._]+$"); // Starts with #
 static const std::regex RESTRICTED_INDICATOR("^[\\$][A-Z0-9._]{3,}$"); // Starts with $
 
-static const std::regex AVIAN_NAMES("^AVN$|^AVIAN$|^AVIAN$|^#AVN$|^#AVIAN$|^#AVIAN$");
+static const std::regex AVIAN_NAMES("^RVN$|^AVN$|^AVIAN$|^AVIAN$|^#AVN$|^#AVIAN$|^#AVIAN$");
 
 bool IsRootNameValid(const std::string& name)
 {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -128,7 +128,7 @@ bool IsTransitioningToX16rt(const CBlockIndex* pindexLast, const CBlockHeader *p
     if (pblock->nTime <= params.nX16rtTimestamp)
         return false;
         
-    int64_t dgwWindow = 0; // RVL does not have DGWPastBlocks so no need to check.
+    int64_t dgwWindow = 0; // AVN does not have DGWPastBlocks so no need to check.
 
     const CBlockIndex* pindex = pindexLast;
     

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -322,7 +322,8 @@ bool CBlockTreeDB::ReadAddressUnspentIndex(uint160 addressHash, int type,
         if (pcursor->GetKey(key) && key.first == DB_ADDRESSUNSPENTINDEX && key.second.hashBytes == addressHash) {
             CAddressUnspentValue nValue;
             if (pcursor->GetValue(nValue)) {
-                if (key.second.asset != "AVN") {
+                // Avian Core <= 3.1.0 uses RVN as the main asset.
+                if (key.second.asset != "AVN" || key.second.asset != "RVN") {
                     unspentOutputs.push_back(std::make_pair(key.second, nValue));
                 }
                 pcursor->Next();


### PR DESCRIPTION
Avian Core <= 3.1.0 uses `RVN` as the main asset. This would cause pre-4.0.0 inputs that haven't been reindex/rescan to appear as `RVN` and not `AVN` causing the wallet to think it's an asset.