### PR TITLE
qt: Improve RPC console

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -426,13 +426,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="fontSmallerButton">
-           <property name="maximumSize">
-            <size>
-             <width>24</width>
-             <height>24</height>
-            </size>
-           </property>
+          <widget class="QToolButton" name="fontSmallerButton">
            <property name="toolTip">
             <string>Decrease font size</string>
            </property>
@@ -445,26 +439,14 @@
            </property>
            <property name="iconSize">
             <size>
-             <width>24</width>
-             <height>16</height>
+             <width>22</width>
+             <height>22</height>
             </size>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="fontBiggerButton">
-           <property name="maximumSize">
-            <size>
-             <width>24</width>
-             <height>24</height>
-            </size>
-           </property>
+          <widget class="QToolButton" name="fontBiggerButton">
            <property name="toolTip">
             <string>Increase font size</string>
            </property>
@@ -477,26 +459,14 @@
            </property>
            <property name="iconSize">
             <size>
-             <width>24</width>
-             <height>16</height>
+             <width>22</width>
+             <height>22</height>
             </size>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="clearButton">
-           <property name="maximumSize">
-            <size>
-             <width>24</width>
-             <height>24</height>
-            </size>
-           </property>
+          <widget class="QToolButton" name="clearButton">
            <property name="toolTip">
             <string>Clear console</string>
            </property>
@@ -510,14 +480,14 @@
             <iconset resource="../avian.qrc">
              <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
            </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
            <property name="shortcut">
             <string notr="true">Ctrl+L</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -1486,15 +1486,6 @@ ReceiveRequestDialog#outUri {
 QWidget#RPCConsole QLabel#label_9,
 QWidget#RPCConsole QLabel#labelNetwork,
 QWidget#RPCConsole QLabel#label_10,
-QWidget#RPCConsole QLabel#labelMempoolTitle,
-QWidget#RPCConsole QLabel#label_repair_header,
-QWidget#RPCConsole QLabel#peerHeading,
-QWidget#RPCConsole QLabel#banHeading {
-}
-
-QWidget#RPCConsole QLabel#label_9,
-QWidget#RPCConsole QLabel#labelNetwork,
-QWidget#RPCConsole QLabel#label_10,
 QWidget#RPCConsole QLabel#labelMempoolTitle {
     qproperty-alignment: 'AlignLeft | AlignBottom';
     min-height: 25px;
@@ -1507,7 +1498,6 @@ QWidget#RPCConsole  QLabel#banHeading {
     margin-bottom: 15px;
     font-weight: bold;
 }
-
 
 QWidget#RPCConsole QPushButton#promptIcon {
     background-color: #2E2E2E;
@@ -1545,10 +1535,8 @@ QWidget#RPCConsole QLineEdit#lineEdit {
 }
 
 QWidget#RPCConsole .QToolButton {
-    background-color: transparent;
     margin-left: 3px;
-    margin-bottom:5px;
-    border: 0;
+    margin-bottom: 5px;
 }
 
 QWidget#RPCConsole .QGroupBox #line {

--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -1525,8 +1525,8 @@ QWidget#RPCConsole QPushButton#clearButton {
 }
 
 QWidget#RPCConsole QTextEdit#messagesWidget {
-    background-color: #f4f4f4;
-    color: #110202;    
+    background-color: #272727;
+    color: #ffffff;    
     padding: 10px;
 }
 

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -1483,15 +1483,6 @@ ReceiveRequestDialog#outUri {
 QWidget#RPCConsole QLabel#label_9,
 QWidget#RPCConsole QLabel#labelNetwork,
 QWidget#RPCConsole QLabel#label_10,
-QWidget#RPCConsole QLabel#labelMempoolTitle,
-QWidget#RPCConsole QLabel#label_repair_header,
-QWidget#RPCConsole QLabel#peerHeading,
-QWidget#RPCConsole QLabel#banHeading {
-}
-
-QWidget#RPCConsole QLabel#label_9,
-QWidget#RPCConsole QLabel#labelNetwork,
-QWidget#RPCConsole QLabel#label_10,
 QWidget#RPCConsole QLabel#labelMempoolTitle {
     qproperty-alignment: 'AlignLeft | AlignBottom';
     min-height: 25px;
@@ -1504,7 +1495,6 @@ QWidget#RPCConsole  QLabel#banHeading {
     margin-bottom: 15px;
     font-weight: bold;
 }
-
 
 QWidget#RPCConsole QPushButton#promptIcon {
     background-color: #ffffff;
@@ -1540,10 +1530,8 @@ QWidget#RPCConsole QLineEdit#lineEdit {
 }
 
 QWidget#RPCConsole .QToolButton {
-    background-color: transparent;
     margin-left: 3px;
     margin-bottom:5px;
-    border: 0;
 }
 
 QWidget#RPCConsole .QGroupBox #line {


### PR DESCRIPTION
This PR improves the RPC console by making the buttons look clickable and using a dark background - if on dark mode.

![Screenshot from 2022-08-10 16-31-52](https://user-images.githubusercontent.com/36016500/184046401-efa7348f-2b5a-4286-9cb5-98f0fc71a1c0.png)
