### PR TITLE
qt: Rework Open URI dialog

### DIFF
--- a/src/qt/aviangui.cpp
+++ b/src/qt/aviangui.cpp
@@ -1027,7 +1027,7 @@ void AvianGUI::showHelpMessageClicked()
 #ifdef ENABLE_WALLET
 void AvianGUI::openClicked()
 {
-    OpenURIDialog dlg(this);
+    OpenURIDialog dlg(platformStyle, this);
     if(dlg.exec())
     {
         Q_EMIT receivedURI(dlg.getURI());

--- a/src/qt/forms/openuridialog.ui
+++ b/src/qt/forms/openuridialog.ui
@@ -11,16 +11,9 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Open URI</string>
+   <string>Open avian URI</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Open payment request from URI or file</string>
-     </property>
-    </widget>
-   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -31,18 +24,30 @@
       </widget>
      </item>
      <item>
-      <widget class="QValidatedLineEdit" name="uriEdit"/>
+      <widget class="QValidatedLineEdit" name="uriEdit">
+       <property name="placeholderText">
+        <string notr="true">avian:</string>
+       </property>
+      </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="selectFileButton">
+      <widget class="QToolButton" name="pasteButton">
        <property name="toolTip">
-        <string>Select payment request file</string>
+        <string extracomment="Tooltip text for button that allows you to paste an address that is in your clipboard.">Paste address from clipboard</string>
        </property>
        <property name="text">
-        <string notr="true">…</string>
+        <string/>
        </property>
-       <property name="autoDefault">
-        <bool>false</bool>
+       <property name="icon">
+        <iconset resource="../avian.qrc">
+         <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste
+        </iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>22</width>
+         <height>22</height>
+        </size>
        </property>
       </widget>
      </item>

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2011-2014 The Bitcoin Core developers
-// Copyright (c) 2017-2019 The Raven Core developers
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Copyright (c) 2022 The Avian Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,15 +7,22 @@
 #include "ui_openuridialog.h"
 
 #include "guiutil.h"
+#include "platformstyle.h"
 #include "walletmodel.h"
 
+#include <QAbstractButton>
+#include <QLineEdit>
 #include <QUrl>
 
-OpenURIDialog::OpenURIDialog(QWidget *parent) :
+OpenURIDialog::OpenURIDialog(const PlatformStyle* platformStyle, QWidget* parent) : 
     QDialog(parent),
-    ui(new Ui::OpenURIDialog)
+    ui(new Ui::OpenURIDialog),
+    m_platform_style(platformStyle)
 {
     ui->setupUi(this);
+    ui->pasteButton->setIcon(m_platform_style->SingleColorIcon(":/icons/editpaste"));
+    QObject::connect(ui->pasteButton, &QAbstractButton::clicked, ui->uriEdit, &QLineEdit::paste);
+
 #if QT_VERSION >= 0x040700
     ui->uriEdit->setPlaceholderText("avian:");
 #endif
@@ -34,8 +41,7 @@ QString OpenURIDialog::getURI()
 void OpenURIDialog::accept()
 {
     SendCoinsRecipient rcp;
-    if(GUIUtil::parseAvianURI(getURI(), &rcp))
-    {
+    if (GUIUtil::parseAvianURI(getURI(), &rcp)) {
         /* Only accept value URIs */
         QDialog::accept();
     } else {
@@ -43,11 +49,11 @@ void OpenURIDialog::accept()
     }
 }
 
-void OpenURIDialog::on_selectFileButton_clicked()
+void OpenURIDialog::changeEvent(QEvent* e)
 {
-    QString filename = GUIUtil::getOpenFileName(this, tr("Select payment request file to open"), "", "", nullptr);
-    if(filename.isEmpty())
-        return;
-    QUrl fileUri = QUrl::fromLocalFile(filename);
-    ui->uriEdit->setText("avian:?r=" + QUrl::toPercentEncoding(fileUri.toString()));
+    if (e->type() == QEvent::PaletteChange) {
+        ui->pasteButton->setIcon(m_platform_style->SingleColorIcon(":/icons/editpaste"));
+    }
+
+    QDialog::changeEvent(e);
 }

--- a/src/qt/openuridialog.h
+++ b/src/qt/openuridialog.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2011-2015 The Bitcoin Core developers
-// Copyright (c) 2017-2019 The Raven Core developers
+// Copyright (c) 2011-2020 The Bitcoin Core developers
+// Copyright (c) 2022 The Avian Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,6 +7,8 @@
 #define AVIAN_QT_OPENURIDIALOG_H
 
 #include <QDialog>
+
+class PlatformStyle;
 
 namespace Ui {
     class OpenURIDialog;
@@ -17,19 +19,19 @@ class OpenURIDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit OpenURIDialog(QWidget *parent);
+    explicit OpenURIDialog(const PlatformStyle* platformStyle, QWidget* parent);
     ~OpenURIDialog();
 
     QString getURI();
 
 protected Q_SLOTS:
-    void accept();
-
-private Q_SLOTS:
-    void on_selectFileButton_clicked();
+    void accept() override;
+    void changeEvent(QEvent* e) override;
 
 private:
-    Ui::OpenURIDialog *ui;
+    Ui::OpenURIDialog* ui;
+
+    const PlatformStyle* m_platform_style;
 };
 
 #endif // AVIAN_QT_OPENURIDIALOG_H


### PR DESCRIPTION
This PR reworks the `Open URI` dialog by removing the file selector and adding a button to paste the active clipboard.

*Backport of Bitcoin GUI PR 319.*

