### PR TITLE
block: Cache PoW hashes 

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -216,6 +216,10 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
 
+    //! (currently memory only, but don't have to be)
+    bool cache_init;
+    uint256 cache_PoW_hash;
+
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
 
@@ -243,6 +247,8 @@ public:
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
+
+        cache_init     = false;
     }
 
     CBlockIndex()
@@ -259,6 +265,9 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
+
+        cache_init     = block.cache_init;
+        cache_PoW_hash = block.cache_PoW_hash;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -289,6 +298,10 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+
+        block.cache_init     = cache_init;
+        block.cache_PoW_hash = cache_PoW_hash;
+
         return block;
     }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -218,7 +218,7 @@ public:
 
     //! (currently memory only, but don't have to be)
     bool cache_init;
-    uint256 cache_PoW_hash;
+    uint256 cache_block_hash, cache_PoW_hash;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
@@ -267,6 +267,7 @@ public:
         nNonce         = block.nNonce;
 
         cache_init     = block.cache_init;
+        cache_block_hash = block.cache_block_hash;
         cache_PoW_hash = block.cache_PoW_hash;
     }
 
@@ -300,6 +301,7 @@ public:
         block.nNonce         = nNonce;
 
         block.cache_init     = cache_init;
+        block.cache_block_hash = cache_block_hash;
         block.cache_PoW_hash = cache_PoW_hash;
 
         return block;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -491,7 +491,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Consens
 bool CheckProofOfWork(const CBlockHeader& blockheader, const Consensus::ConsensusParams& params)
 {
 	if (blockheader.GetBlockTime() > params.diffRetargetTake2)
-		return CheckProofOfWorkCrow(blockheader.GetHash(), blockheader.nBits, params, blockheader.GetPoWType());
+		return CheckProofOfWorkCrow(blockheader.GetPoWHashCached(), blockheader.nBits, params, blockheader.GetPoWType());
 	else
-		return CheckProofOfWork(blockheader.GetHash(), blockheader.nBits, params);
+		return CheckProofOfWork(blockheader.GetPoWHashCached(), blockheader.nBits, params);
 }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -121,13 +121,13 @@ uint256 CBlockHeader::GetPoWHashCached() const
             exit(1);
         }
         // yespower cache: log // O (cyan) = HIT
-        printf("\033[36;1mO\033[0m block = %s PoW = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
+        // printf("\033[36;1mO\033[0m block = %s PoW = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
     } else {
         cache_PoW_hash = GetHash();
         cache_block_hash = block_hash;
         cache_init = true;
         // yespower cache: log // x = MISS
-        printf("x block = %s PoW = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
+        // printf("x block = %s PoW = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
     }
     return cache_PoW_hash;
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -100,6 +100,7 @@ public:
 
     uint256 GetHash() const;
     uint256 GetX16RHash() const;
+    uint256 GetSha256Hash() const;
 
     // Crow: MinotaurX
     static uint256 CrowHashArbitrary(const char* data);
@@ -135,7 +136,7 @@ class CBlockHeader : public CBlockHeaderUncached
 public:
     mutable CCriticalSection cache_lock;
     mutable bool cache_init;
-    mutable uint256 cache_PoW_hash;
+    mutable uint256 cache_block_hash, cache_PoW_hash;
 
     CBlockHeader()
     {
@@ -151,6 +152,7 @@ public:
     {
         *(CBlockHeaderUncached*)this = (CBlockHeaderUncached)header;
         cache_init = header.cache_init;
+        cache_block_hash = header.cache_block_hash;
         cache_PoW_hash = header.cache_PoW_hash;
         return *this;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4543,6 +4543,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
             if (!pblock->cache_init && pindex->cache_init) {
                 LOCK(pblock->cache_lock); // Probably unnecessary since no concurrent access to pblock is expected
                 pblock->cache_init = true;
+                pblock->cache_block_hash = pindex->cache_block_hash;
                 pblock->cache_PoW_hash = pindex->cache_PoW_hash;
             }
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -98,8 +98,16 @@ static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
+
 /** Number of blocks that can be requested at any given time from a single peer. */
-static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
+// FIXME - GetPoWHashCached
+/** IBD: which sets MAX_BLOCKS_IN_TRANSIT_PER_PEER to be same as MAX_HEADERS_RESULTS.
+ *  Without this change, at least in Resistance the block headers download would get unnecessarily
+ *  far ahead of the full blocks download, resulting in more work lost and redone in case the
+ *  initial blocks download is interrupted and continued.
+ *  The work loss is because we do not yet store cached PoWs on disk. */
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 2000; // (was 16)
+
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
 static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends


### PR DESCRIPTION
Fixes #127 

Cache PoW hashes for Yespower (MinotaurX) to speed up reindex and IDB since yespower (a cpu heavy hash) is used in GetHash() instead of GetPoWHash().

Opening this PR as a draft.

Backport of:
https://github.com/ResistancePlatform/resistance-core/compare/20c7ba33101133053bd001a84479ff341a134cba...3c80dac3618e42c90057da7ba6fa49c44cf64349