### PR TITLE
cherry-pick: backport: gui: Set CConnman byte counters earlier to avoid uninitialzed reads (#24)

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -367,8 +367,8 @@ private:
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;
     CCriticalSection cs_totalBytesSent;
-    uint64_t nTotalBytesRecv;
-    uint64_t nTotalBytesSent;
+    uint64_t nTotalBytesRecv {0};
+    uint64_t nTotalBytesSent {0};
 
     // outbound limit & stats
     uint64_t nMaxOutboundTotalBytesSentInCycle;


### PR DESCRIPTION
Manual backport of bitcoin PR #17906

Initialize CConnman byte counters during construction, so GetTotalBytesRecv()
and GetTotalBytesSent() methods don't return garbage before Start() is called.

Change shouldn't have any effect outside of the GUI. It just fixes a race
condition during a qt test that was observed on travis:
https://travis-ci.org/bitcoin/bitcoin/jobs/634989685

(cherry picked from commit bb9ee5fae29f582c10895661adf646eaf3eaeb9f)