### PR TITLE
cherry-pick: backport: rpc: Fix data race (UB) in InterruptRPC() (#25)

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -33,7 +33,7 @@ using namespace boost::placeholders;
 
 #include "assets/assets.h"
 
-static bool fRPCRunning = false;
+static std::atomic<bool> g_rpc_running{false};
 static bool fRPCInWarmup = true;
 static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
@@ -393,7 +393,7 @@ bool CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)
 bool StartRPC()
 {
     LogPrint(BCLog::RPC, "Starting RPC\n");
-    fRPCRunning = true;
+    g_rpc_running = true;
     g_rpcSignals.Started();
     return true;
 }
@@ -402,7 +402,7 @@ void InterruptRPC()
 {
     LogPrint(BCLog::RPC, "Interrupting RPC\n");
     // Interrupt e.g. running longpolls
-    fRPCRunning = false;
+    g_rpc_running = false;
 }
 
 void StopRPC()
@@ -415,7 +415,7 @@ void StopRPC()
 
 bool IsRPCRunning()
 {
-    return fRPCRunning;
+    return g_rpc_running;
 }
 
 void SetRPCWarmupStatus(const std::string& newStatus)


### PR DESCRIPTION
manual backport of bitcoin PR # 14993

rpc: Fix data race (UB) in InterruptRPC()
(cherry picked from commit d4e3145c5ced78ee2b6c55c7ffc404929bfc14f0)