### PR TITLE
depends: libevent update (#32)

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,17 +1,19 @@
 package=libevent
-$(package)_version=2.1.8-stable
-$(package)_download_path=https://github.com/libevent/libevent/archive/
-$(package)_file_name=release-$($(package)_version).tar.gz
-$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
+$(package)_version=2.1.12-stable
+$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
-define $(package)_preprocess_cmds
-  ./autogen.sh
-endef
-
+# When building for Windows, we set _WIN32_WINNT to target the same Windows
+# version as we do in configure. Due to quirks in libevents build system, this
+# is also required to enable support for ipv6. See #19375.
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_android=--with-pic
+  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 endef
 
 define $(package)_config_cmds
@@ -27,4 +29,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  rm lib/*.la
 endef

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -20,7 +20,7 @@ These are the dependencies currently used by Avian Core. You can find instructio
 | GCC |  | [4.7+](https://gcc.gnu.org/) |  |  |  |
 | HarfBuzz-NG |  |  |  |  |  |
 | libdmg-hfsplus | | | | | |
-| libevent | [2.1.11-stable](https://github.com/libevent/libevent/releases) | 2.0.22 | No |  |  |
+| libevent | [2.1.12-stable](https://github.com/libevent/libevent/releases) | 2.0.22 | No |  |  |
 | libICE    | 1.0.9  | | | | |
 | libjpeg |  |  |  |  | [Yes](https://github.com/AvianNetwork/Avian/blob/master/depends/packages/qt.mk#L75) |
 | libpng |  |  |  |  | [Yes](https://github.com/AvianNetwork/Avian/blob/master/depends/packages/qt.mk#L74) |


### PR DESCRIPTION
Update libevent to 2.1.12-stable.

https://raw.githubusercontent.com/libevent/libevent/release-2.1.12-stable/ChangeLog
(cherry picked from commit 9e43a43c0fcc9678aecbd0b1fff84eb12aee9162)