### PR TITLE
backport: [qt] Reissue asset spinboxes; disable if unit is max.

### DIFF
--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -609,8 +609,12 @@ void ReissueAssetDialog::onAssetSelected(int index)
         ss.precision(asset->units);
         ss << std::fixed << value.get_real();
 
-        ui->unitSpinBox->setValue(asset->units);
         ui->unitSpinBox->setMinimum(asset->units);
+        ui->unitSpinBox->setValue(asset->units);
+
+        if (asset->units == MAX_ASSET_UNITS) {
+            ui->unitSpinBox->setDisabled(true);
+        }
 
         ui->quantitySpinBox->setMaximum(21000000000 - value.get_real());
 

--- a/src/qt/restrictedfreezeaddress.cpp
+++ b/src/qt/restrictedfreezeaddress.cpp
@@ -166,7 +166,7 @@ void FreezeAddress::check()
 
     bool failed = false;
     if (!IsAssetNameAnRestricted(restricted_asset.toStdString())){
-        showWarning(tr("Must have a restricteds asset selected"));
+        showWarning(tr("Must have a restricted asset selected"));
         failed = true;
     }
 


### PR DESCRIPTION
Backport:
> Disable units spinbox if max units is already set.
> Set minvalue for spinbox after setting value, to allow
> updates when the number of units in the selected asset is
> lower than the number of units in the previous.