### PR TITLE
backport: [qt] Create and reissue asset views add browse IPFS button

### DIFF
--- a/src/qt/createassetdialog.h
+++ b/src/qt/createassetdialog.h
@@ -86,7 +86,7 @@ private:
     void setQualifierSelected();
     void clearSelected();
 
-    //CoinControl
+    // CoinControl
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
 
@@ -94,12 +94,14 @@ private:
     void updateFeeMinimizedLabel();
     void minimizeFeeSection(bool fMinimize);
 
-    //Validation
+    // Validation
+    // Returns true if this is an IPFS-hash or TXID.
     bool checkIPFSHash(QString hash);
 
 private Q_SLOTS:
     void ipfsStateChanged();
     void checkAvailabilityClicked();
+    void openIpfsBrowser();
     void onNameChanged(QString name);
     void onAddressNameChanged(QString address);
     void onIPFSHashChanged(QString hash);

--- a/src/qt/forms/createassetdialog.ui
+++ b/src/qt/forms/createassetdialog.ui
@@ -827,6 +827,13 @@
             </property>
            </widget>
           </item>
+            <item>
+             <widget class="QPushButton" name="openIpfsButton">
+              <property name="text">
+               <string>Browse IPFS</string>
+              </property>
+             </widget>
+            </item>
          </layout>
         </item>
         <item>

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -895,6 +895,13 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QPushButton" name="openIpfsButton">
+                <property name="text">
+                 <string>Browse IPFS</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -40,6 +40,8 @@
 #include <QStringListModel>
 #include <QSortFilterProxyModel>
 #include <QCompleter>
+#include <QUrl>
+#include <QDesktopServices>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #define QTversionPreFiveEleven
@@ -56,6 +58,7 @@ ReissueAssetDialog::ReissueAssetDialog(const PlatformStyle *_platformStyle, QWid
     connect(ui->comboBox, SIGNAL(activated(int)), this, SLOT(onAssetSelected(int)));
     connect(ui->quantitySpinBox, SIGNAL(valueChanged(double)), this, SLOT(onQuantityChanged(double)));
     connect(ui->ipfsBox, SIGNAL(clicked()), this, SLOT(onIPFSStateChanged()));
+    connect(ui->openIpfsButton, SIGNAL(clicked()), this, SLOT(openIpfsBrowser()));
     connect(ui->ipfsText, SIGNAL(textChanged(QString)), this, SLOT(onIPFSHashChanged(QString)));
     connect(ui->addressText, SIGNAL(textChanged(QString)), this, SLOT(onAddressNameChanged(QString)));
     connect(ui->reissueAssetButton, SIGNAL(clicked()), this, SLOT(onReissueAssetClicked()));
@@ -270,6 +273,7 @@ void ReissueAssetDialog::setUpValues()
 
     ui->reissuableBox->setCheckState(Qt::CheckState::Checked);
     ui->ipfsText->setDisabled(true);
+    ui->openIpfsButton->setDisabled(true);
     hideMessage();
 
     ui->unitExampleLabel->setStyleSheet("font-weight: bold");
@@ -405,9 +409,14 @@ void ReissueAssetDialog::CheckFormState()
         }
     }
 
-    if (ui->ipfsBox->isChecked())
-        if (!checkIPFSHash(ui->ipfsText->text()))
+    if (ui->ipfsBox->isChecked()) {
+        if (!checkIPFSHash(ui->ipfsText->text())) {
+            ui->openIpfsButton->setDisabled(true);
             return;
+        }
+        else
+            ui->openIpfsButton->setDisabled(false);
+    }
 
     if (fReissuingRestricted) {
 
@@ -725,6 +734,26 @@ void ReissueAssetDialog::onIPFSHashChanged(QString hash)
         CheckFormState();
 
     buildUpdatedData();
+}
+
+void ReissueAssetDialog::openIpfsBrowser()
+{
+    QString ipfshash = ui->ipfsText->text();
+    QString ipfsbrowser = model->getOptionsModel()->getIpfsUrl();
+
+    // If the ipfs hash isn't there or doesn't start with Qm, disable the action item
+    if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0 && ipfsbrowser.indexOf("http") == 0)
+    {
+        QUrl ipfsurl = QUrl::fromUserInput(ipfsbrowser.replace("%s", ipfshash));
+
+        // Create the box with everything.
+        if(QMessageBox::Yes == QMessageBox::question(this,
+                                                        tr("Open IPFS content?"),
+                                                        tr("Open the following IPFS content in your default browser?\n")
+                                                        + ipfsurl.toString()
+                                                    ))
+        QDesktopServices::openUrl(ipfsurl);
+    }
 }
 
 void ReissueAssetDialog::onAddressNameChanged(QString address)

--- a/src/qt/reissueassetdialog.h
+++ b/src/qt/reissueassetdialog.h
@@ -105,6 +105,7 @@ private Q_SLOTS:
     void onUnitChanged(int value);
     void onClearButtonClicked();
     void onVerifierStringChanged(QString verifier);
+    void openIpfsBrowser();
 
     //CoinControl
     void coinControlFeatureChanged(bool);


### PR DESCRIPTION
Backport

> * Add button to open ipfs-hash in the configured ipfs-viewer.
>  This can be handy to verify your ipfs-hash is correct, before creating the asset.
>
> * Remove a check that enabled the Check Availability button once the `Add IPFS/Txid hash` was enabled.