### PR TITLE
validation: Do not check PoW when downloading headers during IBD

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4032,7 +4032,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::C
         return true;
 
     // Check that the header is valid (particularly PoW).  This is mostly
-    // redundant with the call in AcceptBlockHeader.
+    // redundant with the call in AcceptBlockHeader, but when IBD mode, it's SKIPPED.
     if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
         return false;
 
@@ -4372,7 +4372,8 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
             return true;
         }
 
-        if (!CheckBlockHeader(block, state, chainparams.GetConsensus()))
+        // IBD: Do not check PoW when downloading headers for performance reason
+        if (!IsInitialBlockDownload() && !CheckBlockHeader(block, state, chainparams.GetConsensus()))
             return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
         // Get prev block index


### PR DESCRIPTION
This PR skips check header (PoW), only when downloading headers.

This reduces a bottleneck when downloading block headers during the initial block download.
Tested on mainnet with IBD speed increase of ~22%

# What is being skipped?
Skipped `CheckProofOfWork()` in `pow.cpp` when accepting headers (during IDB).

# Is this safe?
`CheckProofOfWork()` is already checked in several places. 

`CheckProofOfWork()` is called by `CheckBlock()` which is called multiple times.

In `CheckBlock()`
```cpp
    // Check that the header is valid (particularly PoW).  This is mostly
    // redundant with the call in AcceptBlockHeader.
    if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
        return false;
```