### PR TITLE
trivial: Rename ambiguous UAHFs (FORKID and unused assets)

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -26,11 +26,8 @@ static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
-/** Timestamp at which the UAHF starts. */
-static const uint64_t DEFAULT_UAHF_START_TIME = 1585828800;
-
-/** Timestamp at which the UAHF FOR Assets starts. **/
-static const uint64_t DEFAULT_UAHF_FOR_ASSETS_START_TIME = 1601424000;
+/** Timestamp at which the FORK ID UAHF starts. */
+static const uint64_t DEFAULT_FORKID_UAHF_START_TIME = 1585828800;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1980,7 +1980,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 #endif
 
     int nHashType = SIGHASH_ALL;
-    if (IsUAHFenabledForCurrentBlock()) {
+    if (IsForkIDUAHFenabledForCurrentBlock()) {
         nHashType |= SIGHASH_FORKID;
     }    
     if (!request.params[3].isNull()) {

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -221,7 +221,7 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPu
     sigdata.scriptSig = PushAll(result);
 
     // Test solution
-    if (!IsUAHFenabledForCurrentBlock()) {
+    if (!IsForkIDUAHFenabledForCurrentBlock()) {
     	return solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker());
     } else {
     	return solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_ENABLE_SIGHASH_FORKID, creator.Checker());
@@ -473,7 +473,7 @@ bool DummySignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, const 
 {
     // Create a dummy signature that is a valid DER-encoding
     uint32_t nHashType = SIGHASH_ALL;
-    if (IsUAHFenabledForCurrentBlock()) {
+    if (IsForkIDUAHFenabledForCurrentBlock()) {
         nHashType |= SIGHASH_FORKID;
     }
     vchSig.assign(72, '\000');

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -428,24 +428,22 @@ static bool IsCurrentForFeeEstimation()
     return true;
 }
 
-//static bool IsUAHFenabled(const Config &config, int64_t nMedianTimePast) {
-static bool IsUAHFenabled(int64_t nMedianTimePast) {
-    return nMedianTimePast >= DEFAULT_UAHF_START_TIME ;
+/** FORKID UAHF (from RVC) */
+static bool IsForkIDUAHFenabled(int64_t nMedianTimePast) {
+    return nMedianTimePast >= DEFAULT_FORKID_UAHF_START_TIME;
 }
 
-//bool IsUAHFenabled(const Config &config, const CBlockIndex *pindexPrev) {
-bool IsUAHFenabled(const CBlockIndex *pindexPrev) {
+bool IsForkIDUAHFenabled(const CBlockIndex *pindexPrev) {
     if (pindexPrev == nullptr) {
         return false;
     }
 
-    return IsUAHFenabled(pindexPrev->GetMedianTimePast());
+    return IsForkIDUAHFenabled(pindexPrev->GetMedianTimePast());
 }
 
-//bool IsUAHFenabledForCurrentBlock(const Config &config) {
-bool IsUAHFenabledForCurrentBlock() {
+bool IsForkIDUAHFenabledForCurrentBlock() {
     AssertLockHeld(cs_main);
-    return IsUAHFenabled(chainActive.Tip());
+    return IsForkIDUAHFenabled(chainActive.Tip());
 }
 
 /* Make mempool consistent after a reorg, by re-adding or recursively erasing
@@ -908,7 +906,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             scriptVerifyFlags = gArgs.GetArg("-promiscuousmempoolflags", scriptVerifyFlags);
         }
 
-        const bool hasUAHF = IsUAHFenabledForCurrentBlock();
+        const bool hasUAHF = IsForkIDUAHFenabledForCurrentBlock();
         if (hasUAHF) {
             scriptVerifyFlags |= SCRIPT_ENABLE_SIGHASH_FORKID;
         }
@@ -2539,7 +2537,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
 
     // Get the script flags for this block
     unsigned int flags = GetBlockScriptFlags(pindex, chainparams.GetConsensus());
-    const bool hasUAHF = IsUAHFenabledForCurrentBlock();
+    const bool hasUAHF = IsForkIDUAHFenabledForCurrentBlock();
     if (hasUAHF) {
         flags |= SCRIPT_VERIFY_STRICTENC;
         flags |= SCRIPT_ENABLE_SIGHASH_FORKID;
@@ -2917,7 +2915,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
 
     // If this block activates UAHF, we clear the mempool. This ensure that
     // we'll only get replay protected transaction in the mempool going forward.
-    if (!hasUAHF && IsUAHFenabled(pindex)) {
+    if (!hasUAHF && IsForkIDUAHFenabled(pindex)) {
         mempool.clear();
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -448,27 +448,6 @@ bool IsUAHFenabledForCurrentBlock() {
     return IsUAHFenabled(chainActive.Tip());
 }
 
-
-//static bool IsUAHFForAssetsenabled(const Config &config, int64_t nMedianTimePast) {
-static bool IsUAHFForAssetsenabled(int64_t nMedianTimePast) {
-    return nMedianTimePast >= DEFAULT_UAHF_FOR_ASSETS_START_TIME ;
-}
-
-//bool IsUAHFenabled(const Config &config, const CBlockIndex *pindexPrev) {
-bool IsUAHFForAssetsenabled(const CBlockIndex *pindexPrev) {
-    if (pindexPrev == nullptr) {
-        return false;
-    }
-
-    return IsUAHFForAssetsenabled(pindexPrev->GetMedianTimePast());
-}
-
-//bool IsUAHFenabledForCurrentBlock(const Config &config) {
-bool IsUAHFForAssetsenabledForCurrentBlock() {
-    AssertLockHeld(cs_main);
-    return IsUAHFForAssetsenabled(chainActive.Tip());
-}
-
 /* Make mempool consistent after a reorg, by re-adding or recursively erasing
  * disconnected block transactions from the mempool, and also removing any
  * other transactions from the mempool that are no longer valid given the new

--- a/src/validation.h
+++ b/src/validation.h
@@ -346,8 +346,8 @@ void PruneAndFlush();
 void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** Check is FORKID UAHF has activated. */
-bool IsUAHFenabled(const CBlockIndex *pindexPrev);
-bool IsUAHFenabledForCurrentBlock();
+bool IsForkIDUAHFenabled(const CBlockIndex *pindexPrev);
+bool IsForkIDUAHFenabledForCurrentBlock();
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/

--- a/src/validation.h
+++ b/src/validation.h
@@ -345,13 +345,9 @@ void PruneAndFlush();
 /** Prune block files up to a given height */
 void PruneBlockFilesManual(int nManualPruneHeight);
 
-/** Check is UAHF has activated. */
+/** Check is FORKID UAHF has activated. */
 bool IsUAHFenabled(const CBlockIndex *pindexPrev);
 bool IsUAHFenabledForCurrentBlock();
-
-/** Check is UAHF FOR Assets has activated. */
-bool IsUAHFForAssetsenabled(const CBlockIndex *pindexPrev);
-bool IsUAHFForAssetsenabledForCurrentBlock();
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3115,7 +3115,7 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
     CTransaction txNewConst(tx);
     int nIn = 0;
     uint32_t nHashType = SIGHASH_ALL;
-    if (IsUAHFenabledForCurrentBlock()) {
+    if (IsForkIDUAHFenabledForCurrentBlock()) {
         nHashType |= SIGHASH_FORKID;
     }
     for (const auto& input : tx.vin) {
@@ -3742,7 +3742,7 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
             // It is ok to use GetConfig here, because we'll just use replay
             // protected transaction only fairly soon anyway, so we can just
             // remove that call.
-            if (IsUAHFenabledForCurrentBlock()) {
+            if (IsForkIDUAHFenabledForCurrentBlock()) {
                 nHashType |= SIGHASH_FORKID;
             }
             CTransaction txNewConst(txNew);


### PR DESCRIPTION
This PR does **2** things:

- [trival: Remove unused IsUAHFForAssetsenabled](https://github.com/AvianNetwork/Avian/commit/984b3a4366639085ca864fb54a64523be2c15d13)
- [trival: Rename ambiguous UAHF to state FORKID](https://github.com/AvianNetwork/Avian/commit/67f8bf66444155fcc3857124914f6eba6ac75b3f)

While these changes are trivial renames, they are **consensus critical** and MUST be tested rigorously. 