### PR TITLE
backport: Fix bug with in memory qualifier address checking

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -4665,19 +4665,36 @@ bool CAssetsCache::CheckForAddressQualifier(const std::string &qualifier_name, c
 
     setIterator = passets->setNewQualifierAddressToAdd.find(cachedQualifierAddress);
     if (setIterator != passets->setNewQualifierAddressToAdd.end()) {
-        // Return true if we are adding the qualifier, and false if we are removing it
-        return setIterator->type == QualifierType::ADD_QUALIFIER;
+        if (setIterator->type == QualifierType::ADD_QUALIFIER) {
+            return true;
+        } else {
+            // BUG FIX:
+            // This scenario can occur if a tag #TAG is removed from an address in a block, then in a later block
+            // #TAG/#SECOND is added to the address.
+            // If a database event hasn't occurred yet the in memory caches will find that #TAG should be removed from the
+            // address and would normally fail this check. Now we can check for the exact condition where a subqualifier
+            // was added later.
+
+            auto tempChecker = CAssetCacheRootQualifierChecker(qualifier_name, address);
+            if (passets->mapRootQualifierAddressesAdd.count(tempChecker)) {
+                if (passets->mapRootQualifierAddressesAdd.at(tempChecker).size()) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
-    auto tempCache = CAssetCacheRootQualifierChecker(qualifier_name, address);
-    if (!fSkipTempCache && mapRootQualifierAddressesAdd.count(tempCache)){
-        if (mapRootQualifierAddressesAdd[tempCache].size()) {
+    auto tempChecker = CAssetCacheRootQualifierChecker(qualifier_name, address);
+    if (!fSkipTempCache && mapRootQualifierAddressesAdd.count(tempChecker)){
+        if (mapRootQualifierAddressesAdd.at(tempChecker).size()) {
             return true;
         }
     }
 
-    if (passets->mapRootQualifierAddressesAdd.count(tempCache)) {
-        if (passets->mapRootQualifierAddressesAdd[tempCache].size()) {
+    if (passets->mapRootQualifierAddressesAdd.count(tempChecker)) {
+        if (passets->mapRootQualifierAddressesAdd.at(tempChecker).size()) {
             return true;
         }
     }
@@ -4690,7 +4707,6 @@ bool CAssetsCache::CheckForAddressQualifier(const std::string &qualifier_name, c
     }
 
     if (prestricteddb) {
-
         // Check for exact qualifier, and add to cache if it exists
         if (prestricteddb->ReadAddressQualifier(address, qualifier_name)) {
             passetsQualifierCache->Put(cachedQualifierAddress.GetHash().GetHex(), 1);


### PR DESCRIPTION
Backport PR:
> 
    Fix bug in memory check
    Use .at instead of [] checking as this is the correct way to access memory in a map
    rename temp object
