### PR TITLE
Remove unnecessary LogPrintf CreateNewBlock()

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -222,8 +222,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     }
     int64_t nTime2 = GetTimeMicros();
 
-    LogPrint(BCLog::BENCH, "CreateNewBlock() packages: %.2fms (%d packages, %d updated descendants), validity: %.2fms (total %.2fms)\n", 0.001 * (nTime1 - nTimeStart), nPackagesSelected, nDescendantsUpdated, 0.001 * (nTime2 - nTime1), 0.001 * (nTime2 - nTimeStart));
-
     return std::move(pblocktemplate);
 }
 


### PR DESCRIPTION
Remove LogPrintf CreateNewBlock()
Serves no purpose for normal operation other than to inflate debug.log