### PR TITLE
chain: Use correct BIP44 cointype for mainnet (921)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -206,8 +206,8 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
-        // Avian BIP44 cointype in mainnet is '175'
-        nExtCoinType = 175;
+        // Avian BIP44 cointype in mainnet is '921'
+        nExtCoinType = 921;
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 


### PR DESCRIPTION
Use correct BIP44 cointype for mainnet (921).