### PR TITLE
trivial: Cleanup chainparams.cpp

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -16,11 +16,6 @@
 #include <assert.h>
 #include "chainparamsseeds.h"
 
-//TODO: Take these out
-extern double algoHashTotal[16];
-extern int algoHashHits[16];
-
-
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     CMutableTransaction txNew;


### PR DESCRIPTION
Remove unneeded code that stated: `//TODO: Take these out`