### PR TITLE
consensus: Use chain-specific params when calculating PoW hash

### DIFF
--- a/src/aviand.cpp
+++ b/src/aviand.cpp
@@ -111,7 +111,7 @@ bool AppInit(int argc, char* argv[])
         }
         // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
         try {
-            SelectParams(ChainNameFromCommandLine(), true);
+            SelectParams(ChainNameFromCommandLine());
         } catch (const std::exception& e) {
             fprintf(stderr, "Error: %s\n", e.what());
             return false;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -546,7 +546,7 @@ public:
 
         genesis = CreateGenesisBlock(1629951211, 1, 0x207fffff, 2, 2500 * COIN);
 
-        consensus.hashGenesisBlock = genesis.GetHash();
+        consensus.hashGenesisBlock = genesis.GetX16RHash();
         assert(consensus.hashGenesisBlock == uint256S("0x653634d03d27ed84e8aba5dd47903906ad7be4876a1d3677be0db2891dcf787f"));
         assert(genesis.hashMerkleRoot == uint256S("63d9b6b6b549a2d96eb5ac4eb2ab80761e6d7bffa9ae1a647191e08d6416184d"));
 
@@ -640,12 +640,9 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
     throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 
-void SelectParams(const std::string& network, bool fForceBlockNetwork)
+void SelectParams(const std::string& network)
 {
     SelectBaseParams(network);
-    if (fForceBlockNetwork) {
-        bNetwork.SetNetwork(network);
-    }
     globalChainParams = CreateChainParams(network);
 }
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -216,7 +216,7 @@ const CChainParams &Params();
  * Sets the params returned by Params() to those for the given BIP70 chain name.
  * @throws std::runtime_error when the chain is not supported.
  */
-void SelectParams(const std::string& chain, bool fForceBlockNetwork = false);
+void SelectParams(const std::string& chain);
 
 /**
  * Allows modifying the Version Bits regtest parameters.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -431,13 +431,9 @@ std::string HelpMessage(HelpMessageMode mode)
     const auto testnetChainParams = CreateChainParams(CBaseChainParams::TESTNET);
 
     // We want to make sure to set the correct values after we get the help values
-    if (bNetwork.fOnRegtest) {
-        CreateChainParams(CBaseChainParams::REGTEST);
-    } else if (bNetwork.fOnTestnet) {
-        CreateChainParams(CBaseChainParams::TESTNET);
-    } else {
-        CreateChainParams(CBaseChainParams::MAIN);
-    }
+    CreateChainParams(CBaseChainParams::REGTEST);
+    CreateChainParams(CBaseChainParams::TESTNET);
+    CreateChainParams(CBaseChainParams::MAIN);
 
     const bool showDebug = gArgs.GetBoolArg("-help-debug", false);
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -5,18 +5,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "versionbits.h"
+#include "chainparams.h"
 
 #include <cstdint>
 
-#include "chainparams.h"
-
-#include "algo/crow/minotaurx.h"             // Minotaurx Algo
+#include "algo/crow/minotaurx.h" // Minotaurx Algo
 
 #include "primitives/block.h"
 #include "primitives/powcache.h"
 
 #include "algo/hash_algos.h"
+#include "versionbits.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 #include "crypto/common.h"
@@ -27,31 +26,6 @@
 
 #define TIME_MASK 0xffffff80
 
-static const uint32_t MAINNET_X16RT_ACTIVATIONTIME = 1638847406;
-static const uint32_t TESTNET_X16RT_ACTIVATIONTIME = 1634101200;
-static const uint32_t REGTEST_X16RT_ACTIVATIONTIME = 1629951212;
-
-static const uint32_t MAINNET_CROW_MULTI_ACTIVATIONTIME = 1638847407;
-static const uint32_t TESTNET_CROW_MULTI_ACTIVATIONTIME = 1639005225;
-static const uint32_t REGTEST_CROW_MULTI_ACTIVATIONTIME = 1629951212;
-
-BlockNetwork bNetwork = BlockNetwork();
-
-BlockNetwork::BlockNetwork()
-{
-    fOnTestnet = false;
-    fOnRegtest = false;
-}
-
-void BlockNetwork::SetNetwork(const std::string& net)
-{
-    if (net == "test") {
-        fOnTestnet = true;
-    } else if (net == "regtest") {
-        fOnRegtest = true;
-    }
-}
-
 uint256 CBlockHeader::GetSHA256Hash() const
 {
     return SerializeHash(*this);
@@ -61,22 +35,12 @@ uint256 CBlockHeader::ComputePoWHash() const
 {
     uint256 thash;
     unsigned int profile = 0x0;
-    uint32_t nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
-    uint32_t nCrowTimeToUse = MAINNET_CROW_MULTI_ACTIVATIONTIME;
 
-    if (bNetwork.fOnTestnet) {
-        nTimeToUse = TESTNET_X16RT_ACTIVATIONTIME;
-        nCrowTimeToUse = TESTNET_CROW_MULTI_ACTIVATIONTIME;
-    } else if (bNetwork.fOnRegtest) {
-        nTimeToUse = REGTEST_X16RT_ACTIVATIONTIME;
-        nCrowTimeToUse = REGTEST_CROW_MULTI_ACTIVATIONTIME;
-    } else {
-        nTimeToUse = MAINNET_X16RT_ACTIVATIONTIME;
-        nCrowTimeToUse = MAINNET_CROW_MULTI_ACTIVATIONTIME;
-    }
+    uint32_t nX16rtTimestamp = Params().GetConsensus().nX16rtTimestamp;
+    uint32_t nCrowTimestamp = Params().GetConsensus().powForkTime;
 
-    if (nTime > nTimeToUse) {
-        if(nTime > nCrowTimeToUse) {
+    if (nTime > nX16rtTimestamp) {
+        if(nTime > nCrowTimestamp) {
             // Mutli algo (x16rt + new Crow algo)
             switch (GetPoWType()) {
             case POW_TYPE_X16RT: {
@@ -94,7 +58,7 @@ uint256 CBlockHeader::ComputePoWHash() const
             }
         } else {
             // x16rt before dual-algo
-            int32_t nTimeX16r = nTime&TIME_MASK;
+            int32_t nTimeX16r = nTime & TIME_MASK;
             uint256 hashTime = Hash(BEGIN(nTimeX16r), END(nTimeX16r));
             thash = HashX16R(BEGIN(nVersion), END(nNonce), hashTime);
         }
@@ -137,6 +101,7 @@ uint256 CBlockHeader::CrowHashArbitrary(const char* data) {
     return Minotaurx(data, data + strlen(data), true);
 }
 
+// x16r algo
 uint256 CBlockHeader::GetX16RHash() const
 {
     return HashX16R(BEGIN(nVersion), END(nNonce), hashPrevBlock);
@@ -157,36 +122,3 @@ std::string CBlock::ToString() const
     }
     return s.str();
 }
-
-/// Used to test algo switching between X16R and X16RV2
-
-//uint256 CBlockHeader::TestTiger() const
-//{
-//    return HashTestTiger(BEGIN(nVersion), END(nNonce), hashPrevBlock);
-//}
-//
-//uint256 CBlockHeader::TestSha512() const
-//{
-//    return HashTestSha512(BEGIN(nVersion), END(nNonce), hashPrevBlock);
-//}
-//
-//uint256 CBlockHeader::TestGost512() const
-//{
-//    return HashTestGost512(BEGIN(nVersion), END(nNonce), hashPrevBlock);
-//}
-
-//CBlock block = ConsensusParams().GenesisBlock();
-//int64_t nStart = GetTimeMillis();
-//LogPrintf("Starting Tiger %dms\n", nStart);
-//block.TestTiger();
-//LogPrintf("Tiger Finished %dms\n", GetTimeMillis() - nStart);
-//
-//nStart = GetTimeMillis();
-//LogPrintf("Starting Sha512 %dms\n", nStart);
-//block.TestSha512();
-//LogPrintf("Sha512 Finished %dms\n", GetTimeMillis() - nStart);
-//
-//nStart = GetTimeMillis();
-//LogPrintf("Starting Gost512 %dms\n", nStart);
-//block.TestGost512();
-//LogPrintf("Gost512 Finished %dms\n", GetTimeMillis() - nStart);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
 // Copyright (c) 2017 The Raven Core developers
+// Copyright (c) 2022 The Avian Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -42,18 +43,6 @@ enum POW_TYPE {
  * in the block is a special one that creates a new coin owned by the creator
  * of the block.
  */
-
-class BlockNetwork
-{
-public:
-    BlockNetwork();
-    bool fOnRegtest;
-    bool fOnTestnet;
-    void SetNetwork(const std::string& network);
-};
-
-extern BlockNetwork bNetwork;
-
 
 class CBlockHeader
 {
@@ -112,11 +101,6 @@ public:
 
     // Crow: MinotaurX
     static uint256 CrowHashArbitrary(const char* data);
-
-    /// Use for testing algo switch
-    uint256 TestTiger() const;
-    uint256 TestSha512() const;
-    uint256 TestGost512() const;
 
     int64_t GetBlockTime() const
     {

--- a/src/qt/avian.cpp
+++ b/src/qt/avian.cpp
@@ -691,7 +691,7 @@ int main(int argc, char *argv[])
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
-        SelectParams(ChainNameFromCommandLine(), true);
+        SelectParams(ChainNameFromCommandLine());
     } catch(std::exception &e) {
         QMessageBox::critical(0, QObject::tr(PACKAGE_NAME), QObject::tr("Error: %1").arg(e.what()));
         return EXIT_FAILURE;


### PR DESCRIPTION
New version of #90 adapted for v4.2.0

```
This replaces the hard-coded timestamps in block.cpp with the correct Params() timestamp. This commit also changes regtest to use GetX16RHash() since the first block uses X16R and not the dual-algo system.
```

Mainnet, testnet, regtest work as intended.