### PR TITLE
Revert "qt: Remove 'Unknown block versions being mined' warning"

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3181,6 +3181,12 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
         }
         if (nUpgraded > 0)
             warningMessages.push_back(strprintf(_("%d of last 100 blocks have unexpected version"), nUpgraded));
+        if (nUpgraded > 100/2)
+        {
+            std::string strWarning = _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect");
+            // notify GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
+            DoWarning(strWarning);
+        }
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__,
       chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nVersion,


### PR DESCRIPTION
This commit can be reverted safely because now mask out dual algo bits and fixed versionbits bug with 4.0.2 *(backported to 4.1)*.