### PR TITLE
rpc: Fix ANS for RPC commands "createrawtransaction" and "listassets"

### DIFF
--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -1849,6 +1849,7 @@ UniValue listassets(const JSONRPCRequest& request)
             detail.push_back(Pair("units", asset.units));
             detail.push_back(Pair("reissuable", asset.nReissuable));
             detail.push_back(Pair("has_ipfs", asset.nHasIPFS));
+            detail.push_back(Pair("has_ans", asset.nHasANS));
             detail.push_back(Pair("block_height", data.nHeight));
             detail.push_back(Pair("blockhash", data.blockHash.GetHex()));
             if (asset.nHasIPFS) {
@@ -1857,6 +1858,9 @@ UniValue listassets(const JSONRPCRequest& request)
                 } else {
                     detail.push_back(Pair("ipfs_hash", EncodeAssetData(asset.strIPFSHash)));
                 }
+            }
+            if (asset.nHasANS) {
+                detail.push_back(Pair("ans_id", asset.strANSID));
             }
             result.push_back(Pair(asset.strName, detail));
         } else {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -756,7 +756,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
                         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing asset metadata for key: has_ans");                    
 
                     UniValue ans_id = "";
-                    if (ans_id.get_int() == 1) {
+                    if (has_ans.get_int() == 1) {
                         ans_id = find_value(assetData, "ans_id");
                         if (!ans_id.isStr())
                             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing asset metadata for key: ans_id");

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1098,6 +1098,10 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
                     if (!has_ipfs.isNum())
                         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing asset metadata for key: has_ipfs");
 
+                    const UniValue& has_ans = find_value(assetData, "has_ans");
+                    if (!has_ans.isNum())
+                        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing asset metadata for key: has_ans");
+
                     bool fHasOwnerChange = false;
                     const UniValue& owner_change_address = find_value(assetData, "owner_change_address");
                     if (!owner_change_address.isNull()) {
@@ -1117,6 +1121,13 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
                             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing asset metadata for key: has_ipfs");
                     }
 
+                    UniValue ans_id = "";
+                    if (has_ans.get_int() == 1) {
+                        ans_id = find_value(assetData, "ans_id");
+                        if (!ans_id.isStr())
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing asset metadata for key: has_ans");
+                    }
+
                     std::string strAssetName = asset_name.get_str();
 
                     if (!IsAssetNameAnRestricted(strAssetName))
@@ -1134,7 +1145,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 
 
                     // Create a new asset
-                    CNewAsset asset(strAssetName, nAmount, units.get_int(), reissuable.get_int(), has_ipfs.get_int(), DecodeAssetData(ipfs_hash.get_str()));
+                    CNewAsset asset(strAssetName, nAmount, units.get_int(), reissuable.get_int(), has_ipfs.get_int(), DecodeAssetData(ipfs_hash.get_str()), has_ans.get_int(), ans_id.get_str());
 
                     // Verify the new asset data
                     if (!ContextualCheckNewAsset(currentActiveAssetCache, asset, strError)) {
@@ -1221,6 +1232,14 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
                             throw JSONRPCError(RPC_INVALID_PARAMETER,
                                                "Invalid parameter, missing reissue metadata for key: ipfs_hash");
                         reissueObj.strIPFSHash = DecodeAssetData(ipfs_hash.get_str());
+                    }
+
+                    const UniValue &ans_id = find_value(reissueData, "ans_id");
+                    if (!ans_id.isNull()) {
+                        if (!ans_id.isStr())
+                            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                               "Invalid parameter, missing reissue metadata for key: ans_id");
+                        reissueObj.strANSID = ans_id.get_str();
                     }
 
                     bool fHasOwnerChange = false;


### PR DESCRIPTION
This PR fixes ANS RPC commands:
[rpc: Fix ANS checking in createrawtransaction](https://github.com/AvianNetwork/Avian/commit/e1f85fd0ea7fd8a6e231cf81e73db6c00f41ed23)
[rpc: Add ANS checking to restricted and reissue](https://github.com/AvianNetwork/Avian/commit/4faccc6a305b2b5276fb565df21639a6e0d5be98)
[rpc: Add ANS info to verbose listassets](https://github.com/AvianNetwork/Avian/commit/52159d898d84b54e35022714b8d80030f2dfb95f)