### PR TITLE
qt+init: Make PoW cache error more verbose

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1412,7 +1412,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     CFlatDB<CPowCache> flatdb7(strDBName, "powCache");
     if(!flatdb7.Load(CPowCache::Instance())) {
-        return InitError(_("Failed to load POW cache from") + "\n" + (pathDB / strDBName).string());
+        return InitError(_("Failed to load POW cache from") + "\n" + (pathDB / strDBName).string() + "\n\n" + "Delete this file and it will be recreated.");
     }
 
     // ********************************************************* Step 7: network initialization


### PR DESCRIPTION
Fixes #188

When the powcache.dat file becomes corrupt due to forced shutdown, loss-of-power, or other conditions the wallet will return an error. This PR makes clear what the end-user should do to fix the problem; therefore, we are more verbose in this error.

![Screenshot from 2022-11-09 15-05-49](https://user-images.githubusercontent.com/36016500/200932509-4bcd3034-bf27-4460-a6e4-24c26b708d7c.png)
