### PR TITLE
net: Disconnect peers not advertising support for assets

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -21,8 +21,11 @@ static const int GETHEADERS_VERSION = 31800;
 //! assetdata network request is allowed for this version
 static const int ASSETDATA_VERSION = 70017;
 
-//! x16rt + crow algo
+//! x16rt + minotaurx algo
 static const int CROW_VERSION = 70031;
+
+//! asset activation
+static const int ASSETS_VERSION = 70033;
 
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION = CROW_VERSION;


### PR DESCRIPTION
This PR disconnects peers that do not advertise support for assets. This effectively drops support for 3.x.x and 4.0.x. 