### PR TITLE
rpc: remove leading newline from index RPC help

### DIFF
--- a/src/rpc/indexes.cpp
+++ b/src/rpc/indexes.cpp
@@ -100,7 +100,7 @@ static bool timestampSort(const std::pair<CMempoolAddressDeltaKey, CMempoolAddre
 static RPCHelpMan getaddressmempool()
 {
     return RPCHelpMan{"getaddressmempool",
-        "\nReturns all mempool deltas for an address (requires addressindex to be enabled).\n",
+        "Returns all mempool deltas for an address (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Address object",
                 {
@@ -193,7 +193,7 @@ static RPCHelpMan getaddressmempool()
 static RPCHelpMan getaddressutxos()
 {
     return RPCHelpMan{"getaddressutxos",
-        "\nReturns all unspent outputs for an address (requires addressindex to be enabled).\n",
+        "Returns all unspent outputs for an address (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Address object",
                 {
@@ -317,7 +317,7 @@ static RPCHelpMan getaddressutxos()
 static RPCHelpMan getaddressdeltas()
 {
     return RPCHelpMan{"getaddressdeltas",
-        "\nReturns all changes for an address (requires addressindex to be enabled).\n",
+        "Returns all changes for an address (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Address object",
                 {
@@ -462,7 +462,7 @@ static RPCHelpMan getaddressdeltas()
 static RPCHelpMan getaddressbalance()
 {
     return RPCHelpMan{"getaddressbalance",
-        "\nReturns the balance for an address(es) (requires addressindex to be enabled).\n",
+        "Returns the balance for an address(es) (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Address object",
                 {
@@ -549,7 +549,7 @@ static RPCHelpMan getaddressbalance()
 static RPCHelpMan getaddresstxids()
 {
     return RPCHelpMan{"getaddresstxids",
-        "\nReturns the txids for an address(es) (requires addressindex to be enabled).\n",
+        "Returns the txids for an address(es) (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Address object",
                 {
@@ -661,7 +661,7 @@ static RPCHelpMan getaddresstxids()
 static RPCHelpMan getspentinfo()
 {
     return RPCHelpMan{"getspentinfo",
-        "\nReturns the txid and index where an output is spent.\n",
+        "Returns the txid and index where an output is spent.\n",
         {
             {"txid_index", RPCArg::Type::OBJ, RPCArg::Optional::NO, "Transaction output identifier",
                 {


### PR DESCRIPTION
## Summary
Removes the leading newline from several index RPC help descriptions.

## Why
This cleans up RPC help output formatting and avoids unnecessary blank lines in the help text.

## Change
- removes the leading `\n` from affected index RPC help strings

## Testing
- build only
- verified help text formatting change