### PR TITLE
x16r/minotaurx: make PoW hashing compiler-safe and deterministic

### DIFF
--- a/src/algo/minotaurx/sph_types.h
+++ b/src/algo/minotaurx/sph_types.h
@@ -48,6 +48,7 @@
 #define RING_CRYPTO_POW_SPH_TYPES_H
 
 #include <limits.h>
+#include <string.h>
 
 /*
  * All our I/O functions are defined over octet streams. We do not know
@@ -1427,16 +1428,32 @@ sph_dec32be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #else
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
 #if SPH_LITTLE_ENDIAN
-		return sph_bswap32(*(const sph_u32 *)src);
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap32(tmp);
+		}
 #else
-		return *(const sph_u32 *)src;
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return ((sph_u32)(((const unsigned char *)src)[0]) << 24)
@@ -1464,9 +1481,17 @@ static SPH_INLINE sph_u32
 sph_dec32be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #else
 	return ((sph_u32)(((const unsigned char *)src)[0]) << 24)
 		| ((sph_u32)(((const unsigned char *)src)[1]) << 16)
@@ -1545,9 +1570,17 @@ sph_dec32le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #else
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
@@ -1584,10 +1617,18 @@ sph_dec32le(const void *src)
 		return tmp;
  */
 #else
-		return sph_bswap32(*(const sph_u32 *)src);
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap32(tmp);
+		}
 #endif
 #else
-		return *(const sph_u32 *)src;
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return (sph_u32)(((const unsigned char *)src)[0])
@@ -1615,7 +1656,11 @@ static SPH_INLINE sph_u32
 sph_dec32le_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #elif SPH_BIG_ENDIAN
 #if SPH_SPARCV9_GCC && !SPH_NO_ASM
 	sph_u32 tmp;
@@ -1632,7 +1677,11 @@ sph_dec32le_aligned(const void *src)
 	return tmp;
  */
 #else
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #endif
 #else
 	return (sph_u32)(((const unsigned char *)src)[0])
@@ -1726,16 +1775,32 @@ sph_dec64be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #else
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {
 #if SPH_LITTLE_ENDIAN
-		return sph_bswap64(*(const sph_u64 *)src);
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap64(tmp);
+		}
 #else
-		return *(const sph_u64 *)src;
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return ((sph_u64)(((const unsigned char *)src)[0]) << 56)
@@ -1771,9 +1836,17 @@ static SPH_INLINE sph_u64
 sph_dec64be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #else
 	return ((sph_u64)(((const unsigned char *)src)[0]) << 56)
 		| ((sph_u64)(((const unsigned char *)src)[1]) << 48)
@@ -1868,9 +1941,17 @@ sph_dec64le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #else
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {
@@ -1896,10 +1977,18 @@ sph_dec64le(const void *src)
 		return tmp;
  */
 #else
-		return sph_bswap64(*(const sph_u64 *)src);
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap64(tmp);
+		}
 #endif
 #else
-		return *(const sph_u64 *)src;
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return (sph_u64)(((const unsigned char *)src)[0])
@@ -1935,7 +2024,11 @@ static SPH_INLINE sph_u64
 sph_dec64le_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #elif SPH_BIG_ENDIAN
 #if SPH_SPARCV9_GCC_64 && !SPH_NO_ASM
 	sph_u64 tmp;
@@ -1955,7 +2048,11 @@ sph_dec64le_aligned(const void *src)
 	return tmp;
  */
 #else
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #endif
 #else
 	return (sph_u64)(((const unsigned char *)src)[0])

--- a/src/algo/x16r/bmw.c
+++ b/src/algo/x16r/bmw.c
@@ -613,6 +613,7 @@ static const sph_u32 final_s[16] = {
 static void
 bmw32_init(sph_bmw_small_context *sc, const sph_u32 *iv)
 {
+	memset(sc, 0, sizeof(sph_bmw_small_context));
 	memcpy(sc->H, iv, sizeof sc->H);
 	sc->ptr = 0;
 #if SPH_64
@@ -763,6 +764,7 @@ static const sph_u64 final_b[16] = {
 static void
 bmw64_init(sph_bmw_big_context *sc, const sph_u64 *iv)
 {
+	memset(sc, 0, sizeof(sph_bmw_big_context));
 	memcpy(sc->H, iv, sizeof sc->H);
 	sc->ptr = 0;
 	sc->bit_count = 0;

--- a/src/algo/x16r/sph_types.h
+++ b/src/algo/x16r/sph_types.h
@@ -48,6 +48,7 @@
 #define SPH_TYPES_H__
 
 #include <limits.h>
+#include <string.h>
 
 /*
  * All our I/O functions are defined over octet streams. We do not know
@@ -1427,16 +1428,32 @@ sph_dec32be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #else
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
 #if SPH_LITTLE_ENDIAN
-		return sph_bswap32(*(const sph_u32 *)src);
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap32(tmp);
+		}
 #else
-		return *(const sph_u32 *)src;
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return ((sph_u32)(((const unsigned char *)src)[0]) << 24)
@@ -1464,9 +1481,17 @@ static SPH_INLINE sph_u32
 sph_dec32be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #else
 	return ((sph_u32)(((const unsigned char *)src)[0]) << 24)
 		| ((sph_u32)(((const unsigned char *)src)[1]) << 16)
@@ -1545,9 +1570,17 @@ sph_dec32le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #else
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
@@ -1584,10 +1617,18 @@ sph_dec32le(const void *src)
 		return tmp;
  */
 #else
-		return sph_bswap32(*(const sph_u32 *)src);
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap32(tmp);
+		}
 #endif
 #else
-		return *(const sph_u32 *)src;
+		{
+			sph_u32 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return (sph_u32)(((const unsigned char *)src)[0])
@@ -1615,7 +1656,11 @@ static SPH_INLINE sph_u32
 sph_dec32le_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return *(const sph_u32 *)src;
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #elif SPH_BIG_ENDIAN
 #if SPH_SPARCV9_GCC && !SPH_NO_ASM
 	sph_u32 tmp;
@@ -1632,7 +1677,11 @@ sph_dec32le_aligned(const void *src)
 	return tmp;
  */
 #else
-	return sph_bswap32(*(const sph_u32 *)src);
+	{
+		sph_u32 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap32(tmp);
+	}
 #endif
 #else
 	return (sph_u32)(((const unsigned char *)src)[0])
@@ -1726,16 +1775,32 @@ sph_dec64be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #else
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {
 #if SPH_LITTLE_ENDIAN
-		return sph_bswap64(*(const sph_u64 *)src);
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap64(tmp);
+		}
 #else
-		return *(const sph_u64 *)src;
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return ((sph_u64)(((const unsigned char *)src)[0]) << 56)
@@ -1771,9 +1836,17 @@ static SPH_INLINE sph_u64
 sph_dec64be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #else
 	return ((sph_u64)(((const unsigned char *)src)[0]) << 56)
 		| ((sph_u64)(((const unsigned char *)src)[1]) << 48)
@@ -1868,9 +1941,17 @@ sph_dec64le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #else
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {
@@ -1896,10 +1977,18 @@ sph_dec64le(const void *src)
 		return tmp;
  */
 #else
-		return sph_bswap64(*(const sph_u64 *)src);
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return sph_bswap64(tmp);
+		}
 #endif
 #else
-		return *(const sph_u64 *)src;
+		{
+			sph_u64 tmp;
+			memcpy(&tmp, src, sizeof tmp);
+			return tmp;
+		}
 #endif
 	} else {
 		return (sph_u64)(((const unsigned char *)src)[0])
@@ -1935,7 +2024,11 @@ static SPH_INLINE sph_u64
 sph_dec64le_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return *(const sph_u64 *)src;
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return tmp;
+	}
 #elif SPH_BIG_ENDIAN
 #if SPH_SPARCV9_GCC_64 && !SPH_NO_ASM
 	sph_u64 tmp;
@@ -1955,7 +2048,11 @@ sph_dec64le_aligned(const void *src)
 	return tmp;
  */
 #else
-	return sph_bswap64(*(const sph_u64 *)src);
+	{
+		sph_u64 tmp;
+		memcpy(&tmp, src, sizeof tmp);
+		return sph_bswap64(tmp);
+	}
 #endif
 #else
 	return (sph_u64)(((const unsigned char *)src)[0])


### PR DESCRIPTION
This PR hardens PoW hashing code against undefined behavior that can surface on newer compilers/optimizers and potentially lead to inconsistent results across builds.

**Changes:**
x16r/bmw: zero-initialize BMW small/big contexts in init (memset), avoiding any influence from uninitialized struct/padding bytes.
pow/sphlib: update sph_dec32* / sph_dec64* decode helpers to load words via memcpy into a temporary before optional byte-swap, avoiding strict-aliasing and unaligned-load UB.

**Notes:**
No intended functional/consensus changes on correct builds; this is a correctness/determinism hardening.
Applies to both x16r and minotaurx sphlib copies where the decode helpers are used.

**Testing:**
Builds/CI should be sufficient; no new runtime behavior expected.