### PR TITLE
Fix UnitValueFromAmount display and add unit test

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -5211,21 +5211,27 @@ std::string GetUserErrorString(const ErrorReport& report)
 
 UniValue UnitValueFromAmount(const CAmount& amount, int8_t units)
 {
-    bool sign = amount < 0;
-    int64_t n_abs = (sign ? -amount : amount);
-    int64_t quotient = n_abs;
-    int64_t remainder = 0;
+    // Asset amounts are stored as CAmount in 1e-8 base units (like AVN).
+    // The asset's `units` field restricts the displayed/allowed decimal places.
+    // For example, an asset issued with amount 10 and units=0 is stored as
+    // 10 * COIN internally, but should be displayed as "10".
+    const bool sign{amount < 0};
+    const int64_t n_abs{sign ? -amount : amount};
 
-    if (units > 0) {
-        int64_t divisor = 1;
-        for (int i = 0; i < units; i++) divisor *= 10;
-        quotient = n_abs / divisor;
-        remainder = n_abs % divisor;
-    }
+    // Clamp units to the supported range.
+    if (units < 0) units = 0;
+    if (units > MAX_UNIT) units = MAX_UNIT;
+
+    const int64_t quotient{n_abs / COIN};
+    const int64_t remainder_full{n_abs % COIN};
 
     if (units == 0) {
         return UniValue(UniValue::VNUM, strprintf("%s%d", sign ? "-" : "", quotient));
     }
+
+    int64_t remainder_divisor{1};
+    for (int i = 0; i < (MAX_UNIT - units); ++i) remainder_divisor *= 10;
+    const int64_t remainder{remainder_full / remainder_divisor};
 
     return UniValue(UniValue::VNUM, strprintf("%s%d.%0*d", sign ? "-" : "", quotient, units, remainder));
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(test_bitcoin
   addrman_tests.cpp
   allocator_tests.cpp
   amount_tests.cpp
+  assets_amount_tests.cpp
   argsman_tests.cpp
   arith_uint256_tests.cpp
   banman_tests.cpp

--- a/src/test/assets_amount_tests.cpp
+++ b/src/test/assets_amount_tests.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <assets/assets.h>
+#include <consensus/amount.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(assets_amount_tests)
+
+BOOST_AUTO_TEST_CASE(UnitValueFromAmountFormatting)
+{
+    // Regression: an asset issued with amount=10 and units=0 is stored as 10 * COIN,
+    // but should be displayed as "10" (not 10 * COIN).
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(10 * COIN, /*units=*/0).getValStr(), "10");
+
+    // Full precision (units=8) matches base-unit representation.
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(10 * COIN, /*units=*/8).getValStr(), "10.00000000");
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(1 * COIN + 12345678, /*units=*/8).getValStr(), "1.12345678");
+
+    // Truncation to fewer decimals.
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(1 * COIN + 12345678, /*units=*/2).getValStr(), "1.12");
+
+    // Integer display truncates remainder.
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(1 * COIN + 999, /*units=*/0).getValStr(), "1");
+
+    // Negative values preserve sign.
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(-(1 * COIN + 50000000), /*units=*/2).getValStr(), "-1.50");
+
+    // Units clamping.
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(1 * COIN + 1, /*units=*/100).getValStr(), "1.00000001");
+    BOOST_CHECK_EQUAL(UnitValueFromAmount(1 * COIN + 1, /*units=*/-3).getValStr(), "1");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fix amount formatting to respect COIN-scaled storage and units, and add a unit test covering units=0 regression and decimal truncation.
This pull request improves the handling and formatting of asset amounts, especially regarding how they are displayed based on their unit precision. It also adds new tests to ensure correct formatting and clamps unit values to valid ranges.

**Asset amount formatting improvements:**

* Refactored `UnitValueFromAmount` in `assets.cpp` to always interpret amounts in base units (like AVN), clamp the `units` argument to a supported range, and ensure correct decimal formatting for asset display.

**Testing enhancements:**

* Added a new test file `assets_amount_tests.cpp` with comprehensive tests for asset amount formatting, including edge cases for units, sign, and truncation.
* Registered the new test file in the test build configuration (`CMakeLists.txt`) to ensure it runs with the test suite.