### PR TITLE
Mask asset name and quantity in privacy mode

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -147,6 +147,8 @@ class AssetViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT
 public:
+    bool m_privacy{false};
+
     explicit AssetViewDelegate(const PlatformStyle* _platformStyle, QObject* parent = nullptr)
         : QAbstractItemDelegate(parent), platformStyle(_platformStyle)
     {
@@ -232,6 +234,14 @@ public:
         // Get data
         QString name = index.data(AssetTableModel::AssetNameRole).toString();
         QString amountText = index.data(AssetTableModel::FormattedAmountRole).toString();
+        if (m_privacy) {
+            for (int i = 0; i < name.size(); ++i) {
+                if (name[i].isLetterOrNumber()) name[i] = '#';
+            }
+            for (int i = 0; i < amountText.size(); ++i) {
+                if (amountText[i].isDigit()) amountText[i] = '#';
+            }
+        }
 
         // White text
         QColor textColor = COLOR_WHITE;
@@ -358,6 +368,9 @@ void OverviewPage::setPrivacy(bool privacy)
     }
 
     ui->listTransactions->setVisible(!m_privacy);
+
+    assetdelegate->m_privacy = m_privacy;
+    ui->listAssets->viewport()->update();
 
     const QString status_tip = m_privacy ? tr("Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings->Mask values.") : "";
     setStatusTip(status_tip);


### PR DESCRIPTION
This pull request adds a privacy masking feature to the asset list in the Overview page. When privacy mode is enabled, asset names and amounts are obfuscated to protect sensitive information. The most important changes are:

**Privacy Mode Implementation:**

* Added a `m_privacy` boolean member to the `AssetViewDelegate` class to track privacy mode state.
* Modified the asset rendering logic in `AssetViewDelegate` to mask asset names (letters and numbers replaced with `#`) and amounts (digits replaced with `#`) when privacy mode is active.

**Integration with Overview Page:**

* Updated `OverviewPage::setPrivacy` to set the delegate's `m_privacy` flag and refresh the asset list view when privacy mode changes, ensuring the UI updates immediately.