### PR TITLE
Enforce P2PKH addresses for asset operations and validation

### DIFF
--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -43,7 +43,7 @@ static void Base58CheckEncode(benchmark::Bench& bench)
 
 static void Base58Decode(benchmark::Bench& bench)
 {
-    const char* addr = "17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem";
+    const char* addr = "rPC7kPCNPAVnUvQs4fWEvnFwJ4yfKvArXM";
     std::vector<unsigned char> vch;
     bench.batch(strlen(addr)).unit("byte").run([&] {
         (void) DecodeBase58(addr, vch, 64);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -108,21 +108,21 @@ QFont fixedPitchFont(bool use_embedded_font)
     return QFontDatabase::systemFont(QFontDatabase::FixedFont);
 }
 
-// Return a pre-generated dummy bech32m address (P2TR) with invalid checksum.
+// Return a pre-generated dummy legacy (P2PKH) address with invalid checksum.
 static std::string DummyAddress(const CChainParams &params)
 {
     std::string addr;
     switch (params.GetChainType()) {
     case ChainType::MAIN:
-        addr = "bc1p35yvjel7srp783ztf8v6jdra7dhfzk5jaun8xz2qp6ws7z80n4tq2jku9f";
+        addr = "RAvianNetXXXXXXXXXXXXXXXXXXXXXXXXX";
         break;
     case ChainType::SIGNET:
     case ChainType::TESTNET:
     case ChainType::TESTNET4:
-        addr = "tb1p35yvjel7srp783ztf8v6jdra7dhfzk5jaun8xz2qp6ws7z80n4tqa6qnlg";
+        addr = "mAvianTestXXXXXXXXXXXXXXXXXXXXXXXX";
         break;
     case ChainType::REGTEST:
-        addr = "bcrt1p35yvjel7srp783ztf8v6jdra7dhfzk5jaun8xz2qp6ws7z80n4tqsr2427";
+        addr = "mAvianRegXXXXXXXXXXXXXXXXXXXXXXXXX";
         break;
     } // no default case, so the compiler can warn about missing cases
     assert(!addr.empty());

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -442,11 +442,11 @@ void ReissueAssetDialog::CheckFormState()
         return;
     }
 
-    // Check the destination address
+    // Check the destination address (must be legacy P2PKH)
     const CTxDestination dest = DecodeDestination(ui->addressText->text().toStdString());
     if (!ui->addressText->text().isEmpty()) {
-        if (!IsValidDestination(dest)) {
-            showMessage(tr("Invalid Avian Destination Address"));
+        if (std::get_if<PKHash>(&dest) == nullptr) {
+            showMessage(tr("Address must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported."));
             return;
         }
     }

--- a/src/qt/restrictedassetsdialog.cpp
+++ b/src/qt/restrictedassetsdialog.cpp
@@ -17,6 +17,7 @@
 
 #include <assets/assets.h>
 #include <assets/assettypes.h>
+#include <addresstype.h>
 #include <key_io.h>
 #include <validation.h>
 #include <qt/guiconstants.h>
@@ -192,8 +193,8 @@ void RestrictedAssetsDialog::freezeAddressClicked()
     if (fui->checkBoxChangeAddress->isChecked() && !fui->lineEditChangeAddress->text().isEmpty()) {
         change_address = fui->lineEditChangeAddress->text().trimmed().toStdString();
         CTxDestination dest = DecodeDestination(change_address);
-        if (!IsValidDestination(dest)) {
-            QMessageBox::warning(this, tr("Error"), tr("Invalid change address."));
+        if (std::get_if<PKHash>(&dest) == nullptr) {
+            QMessageBox::warning(this, tr("Error"), tr("Change address must use legacy (P2PKH) format."));
             return;
         }
     }
@@ -240,8 +241,8 @@ void RestrictedAssetsDialog::freezeAddressClicked()
             return;
         }
         CTxDestination addr_dest = DecodeDestination(address);
-        if (!IsValidDestination(addr_dest)) {
-            QMessageBox::warning(this, tr("Error"), tr("Invalid address."));
+        if (std::get_if<PKHash>(&addr_dest) == nullptr) {
+            QMessageBox::warning(this, tr("Error"), tr("Address must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported."));
             return;
         }
 
@@ -305,8 +306,8 @@ void RestrictedAssetsDialog::assignQualifierClicked()
         return;
     }
     CTxDestination to_dest = DecodeDestination(to_address);
-    if (!IsValidDestination(to_dest)) {
-        QMessageBox::warning(this, tr("Error"), tr("Invalid address."));
+    if (std::get_if<PKHash>(&to_dest) == nullptr) {
+        QMessageBox::warning(this, tr("Error"), tr("Address must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported."));
         return;
     }
 
@@ -318,8 +319,8 @@ void RestrictedAssetsDialog::assignQualifierClicked()
     if (qui->checkBoxChangeAddress->isChecked() && !qui->lineEditChangeAddress->text().isEmpty()) {
         change_address = qui->lineEditChangeAddress->text().trimmed().toStdString();
         CTxDestination dest = DecodeDestination(change_address);
-        if (!IsValidDestination(dest)) {
-            QMessageBox::warning(this, tr("Error"), tr("Invalid change address."));
+        if (std::get_if<PKHash>(&dest) == nullptr) {
+            QMessageBox::warning(this, tr("Error"), tr("Change address must use legacy (P2PKH) format."));
             return;
         }
     }

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -172,7 +172,7 @@ bool SendAssetsEntry::validate()
     if (recipient.paymentRequest.IsInitialized())
         return retval;
 
-    if (!model->validateAddress(ui->payTo->text()))
+    if (!model->validateLegacyAddress(ui->payTo->text()))
     {
         ui->payTo->setValid(false);
         retval = false;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -17,6 +17,7 @@
 #include <qt/transactiontablemodel.h>
 
 #include <common/args.h>
+#include <addresstype.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
@@ -148,6 +149,12 @@ void WalletModel::updateAddressBook(const QString &address, const QString &label
 bool WalletModel::validateAddress(const QString& address) const
 {
     return IsValidDestinationString(address.toStdString());
+}
+
+bool WalletModel::validateLegacyAddress(const QString& address) const
+{
+    CTxDestination dest = DecodeDestination(address.toStdString());
+    return std::get_if<PKHash>(&dest) != nullptr;
 }
 
 WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -86,6 +86,7 @@ public:
 
     // Check address for validity
     bool validateAddress(const QString& address) const;
+    bool validateLegacyAddress(const QString& address) const;
 
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -44,7 +44,7 @@ using util::SplitString;
 using util::TrimString;
 
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
-const std::string EXAMPLE_ADDRESS[2] = {"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl", "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3"};
+const std::string EXAMPLE_ADDRESS[2] = {"RAvianNetXXXXXXXXXXXXXXXXXXXXXXXXX", "RAvianNet2XXXXXXXXXXXXXXXXXXXXXXXX"};
 
 std::string GetAllOutputTypes()
 {

--- a/src/wallet/asset_tx.cpp
+++ b/src/wallet/asset_tx.cpp
@@ -326,9 +326,17 @@ bool CreateTransferAssetTransaction(
         const std::string& asset_name = transfer.first.strName;
         CAmount nAmount = transfer.first.nAmount;
 
-        if (!IsValidDestinationString(address)) {
-            error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
-            return false;
+        {
+            CTxDestination dest = DecodeDestination(address);
+            if (!IsValidDestination(dest)) {
+                error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+                return false;
+            }
+            if (!std::get_if<PKHash>(&dest)) {
+                error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY,
+                    "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
+                return false;
+            }
         }
 
         if (!VerifyWalletHasAsset(wallet, asset_name, error))
@@ -519,9 +527,17 @@ bool CreateReissueAssetTransaction(
     IsAssetNameValid(asset_name, asset_type);
 
     // Validate destination address
-    if (!IsValidDestinationString(address)) {
-        error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
-        return false;
+    {
+        CTxDestination dest = DecodeDestination(address);
+        if (!IsValidDestination(dest)) {
+            error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+            return false;
+        }
+        if (!std::get_if<PKHash>(&dest)) {
+            error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY,
+                "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
+            return false;
+        }
     }
 
     // Build change address

--- a/src/wallet/rpc/assets.cpp
+++ b/src/wallet/rpc/assets.cpp
@@ -10,6 +10,7 @@
 #include <assets/assetdb.h>
 #include <assets/ans.h>
 #include <assets/messages.h>
+#include <addresstype.h>
 #include <core_io.h>
 #include <key_io.h>
 #include <util/moneystr.h>
@@ -279,6 +280,8 @@ RPCHelpMan issue()
                 CTxDestination destination = DecodeDestination(address);
                 if (!IsValidDestination(destination))
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+                if (!std::get_if<PKHash>(&destination))
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
             } else {
                 auto op_dest = pwallet->GetNewDestination(OutputType::LEGACY, "");
                 if (!op_dest) throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
@@ -377,6 +380,8 @@ RPCHelpMan transfer()
             CTxDestination to_dest = DecodeDestination(to_address);
             if (!IsValidDestination(to_dest))
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + to_address);
+            if (!std::get_if<PKHash>(&to_dest))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
 
             std::string message;
             if (!request.params[3].isNull())
@@ -407,6 +412,8 @@ RPCHelpMan transfer()
             CTxDestination asset_change_dest = DecodeDestination(asset_change_address);
             if (!asset_change_address.empty() && !IsValidDestination(asset_change_dest))
                 throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Asset change address must be a valid address. Invalid address: ") + asset_change_address);
+            if (!asset_change_address.empty() && !std::get_if<PKHash>(&asset_change_dest))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset change address must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
 
             std::vector<std::pair<CAssetTransfer, std::string>> vTransfers;
             CAssetTransfer assetTransfer(asset_name, nAmount, DecodeAssetData(message), expireTime);
@@ -544,6 +551,8 @@ static UniValue UpdateAddressTag(const JSONRPCRequest& request, const int8_t fla
     CTxDestination to_dest = DecodeDestination(to_address);
     if (!IsValidDestination(to_dest))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + to_address);
+    if (!std::get_if<PKHash>(&to_dest))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
 
     std::string change_address;
     if (!request.params[2].isNull())
@@ -617,6 +626,8 @@ static UniValue UpdateAddressRestriction(const JSONRPCRequest& request, const in
     CTxDestination addr_dest = DecodeDestination(address);
     if (!IsValidDestination(addr_dest))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+    if (!std::get_if<PKHash>(&addr_dest))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
 
     std::string change_address;
     if (!request.params[2].isNull())
@@ -799,6 +810,8 @@ RPCHelpMan issueunique()
                 CTxDestination destination = DecodeDestination(address);
                 if (!IsValidDestination(destination))
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+                if (!std::get_if<PKHash>(&destination))
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
             } else {
                 auto op_dest = pwallet->GetNewDestination(OutputType::LEGACY, "");
                 if (!op_dest) throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
@@ -1161,6 +1174,8 @@ RPCHelpMan issuequalifierasset()
                 CTxDestination destination = DecodeDestination(address);
                 if (!IsValidDestination(destination))
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+                if (!std::get_if<PKHash>(&destination))
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
             } else {
                 auto op_dest = pwallet->GetNewDestination(OutputType::LEGACY, "");
                 if (!op_dest) throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, util::ErrorString(op_dest).original);
@@ -1265,6 +1280,8 @@ RPCHelpMan issuerestrictedasset()
             CTxDestination destination = DecodeDestination(address);
             if (!IsValidDestination(destination))
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+            if (!std::get_if<PKHash>(&destination))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
 
             // Validate the verifier string
             std::string strError;
@@ -1374,6 +1391,8 @@ RPCHelpMan reissuerestrictedasset()
             CTxDestination destination = DecodeDestination(address);
             if (!IsValidDestination(destination))
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Avian address: ") + address);
+            if (!std::get_if<PKHash>(&destination))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Asset addresses must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported.");
 
             bool change_verifier = false;
             if (!request.params[3].isNull())


### PR DESCRIPTION
Avian's asset script format (OP_AVN_ASSET) is embedded at byte offset 25 of a P2PKH output, meaning only legacy (P2PKH) addresses are valid destinations for asset operations at the consensus level. SegWit and bech32 addresses will always fail silently when used with assets.

This PR adds explicit enforcement of P2PKH-only addresses at every asset validation site, and replaces residual Bitcoin address placeholders with Avian-format equivalents throughout the codebase.

## Changes
**Enforcement**
- CreateTransferAssetTransaction() and CreateReissueAssetTransaction() now reject non-P2PKH destinations with a clear error message before attempting to build the transaction.
- All asset RPC commands (issue, transfer, issueunique, issuequalifier, transferqualifier, freezeaddress, unfreezeaddress, issuerestrictedasset, reissuerestrictedasset) now validate that supplied addresses decode to a PKHash destination.
- Added validateLegacyAddress() method for use in the GUI layer.
- Asset send form now uses validateLegacyAddress() instead of the generic validateAddress().

**Address placeholder cleanup**
- DummyAddress() replaced Bitcoin bech32m (P2TR) placeholders with Avian P2PKH format addresses.
- array replaced Bitcoin bech32 addresses with Avian P2PKH placeholders.
- benchmark replaced Bitcoin address with an Avian address.