### PR TITLE
Expose per-algo difficulty in getchainstates and getmininginfo

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3445,6 +3445,8 @@ const std::vector<RPCResult> RPCHelpForChainstate{
     {RPCResult::Type::STR_HEX, "bits", "nBits: compact representation of the block difficulty target"},
     {RPCResult::Type::STR_HEX, "target", "The difficulty target"},
     {RPCResult::Type::NUM, "difficulty", "difficulty of the tip"},
+    {RPCResult::Type::NUM, "difficulty_minotaurx", /*optional=*/true, "MinotaurX difficulty of the tip (only after dual-algo activation)"},
+    {RPCResult::Type::NUM, "difficulty_x16rt", /*optional=*/true, "X16RT difficulty of the tip (only after dual-algo activation)"},
     {RPCResult::Type::NUM, "verificationprogress", "progress towards the network tip"},
     {RPCResult::Type::STR_HEX, "snapshot_blockhash", /*optional=*/true, "the base block of the snapshot this chainstate is based on, if any"},
     {RPCResult::Type::NUM, "coins_db_cache_bytes", "size of the coinsdb cache"},
@@ -3489,6 +3491,10 @@ return RPCHelpMan{
         data.pushKV("bits", strprintf("%08x", tip->nBits));
         data.pushKV("target", GetTarget(*tip, chainman.GetConsensus().powLimit).GetHex());
         data.pushKV("difficulty", GetDifficulty(*tip));
+        if (IsDualAlgoEnabled(tip, chainman.GetConsensus())) {
+            data.pushKV("difficulty_minotaurx", GetDifficulty(POW_TYPE_MINOTAURX, chain));
+            data.pushKV("difficulty_x16rt", GetDifficulty(POW_TYPE_X16RT, chain));
+        }
         data.pushKV("verificationprogress", chainman.GuessVerificationProgress(tip));
         data.pushKV("coins_db_cache_bytes",  cs.m_coinsdb_cache_size_bytes);
         data.pushKV("coins_tip_cache_bytes", cs.m_coinstip_cache_size_bytes);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -598,6 +598,8 @@ static RPCHelpMan getmininginfo()
                             {RPCResult::Type::NUM, "height", "The next height"},
                             {RPCResult::Type::STR_HEX, "bits", "The next target nBits"},
                             {RPCResult::Type::NUM, "difficulty", "The next difficulty"},
+                            {RPCResult::Type::NUM, "difficulty_minotaurx", /*optional=*/true, "MinotaurX difficulty for the next block (only after dual-algo activation)"},
+                            {RPCResult::Type::NUM, "difficulty_x16rt", /*optional=*/true, "X16RT difficulty for the next block (only after dual-algo activation)"},
                             {RPCResult::Type::STR_HEX, "target", "The next target"}
                         }},
                         (IsDeprecatedRPCEnabled("warnings") ?
@@ -651,6 +653,10 @@ static RPCHelpMan getmininginfo()
     next.pushKV("height", next_index.nHeight);
     next.pushKV("bits", strprintf("%08x", next_index.nBits));
     next.pushKV("difficulty", GetDifficulty(next_index));
+    if (IsDualAlgoEnabled(&tip, chainman.GetConsensus())) {
+        next.pushKV("difficulty_minotaurx", GetDifficulty(POW_TYPE_MINOTAURX, active_chain));
+        next.pushKV("difficulty_x16rt", GetDifficulty(POW_TYPE_X16RT, active_chain));
+    }
     next.pushKV("target", GetTarget(next_index, chainman.GetConsensus().powLimit).GetHex());
     obj.pushKV("next", next);
 


### PR DESCRIPTION
This pull request enhances the blockchain and mining RPC endpoints to provide more detailed difficulty information after dual-algo activation. Specifically, it adds optional fields for MinotaurX and X16RT difficulties, both in the help documentation and the actual RPC responses, making it easier for clients to track per-algorithm difficulty when the dual-algo system is active.

**RPC output and documentation improvements:**

* Added optional fields `difficulty_minotaurx` and `difficulty_x16rt` to the `getblockchaininfo` and `getmininginfo` RPC result documentation, clarifying that these fields are present only after dual-algo activation (`src/rpc/blockchain.cpp`, `src/rpc/mining.cpp`). [[1]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bR3448-R3449) [[2]](diffhunk://#diff-ccc24453c13307f815879738d3bf00eec351417537fbf10dde1468180cacd2f1R601-R602)
* Updated the logic in both `getblockchaininfo` and `getmininginfo` RPC handlers to include the `difficulty_minotaurx` and `difficulty_x16rt` fields in the response JSON when dual-algo is enabled (`src/rpc/blockchain.cpp`, `src/rpc/mining.cpp`). [[1]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bR3494-R3497) [[2]](diffhunk://#diff-ccc24453c13307f815879738d3bf00eec351417537fbf10dde1468180cacd2f1R656-R659)