### PR TITLE
Show bech32 error message and fix asset dropdown on first open

### DIFF
--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -165,6 +165,7 @@ void AssetsDialog::setModel(WalletModel *_model)
             if(entry)
             {
                 entry->setModel(_model);
+                entry->refreshAssetList();
             }
         }
 

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -517,6 +517,12 @@ void CreateAssetDialog::CheckFormState()
         return;
     }
 
+    if (!ui->addressText->text().isEmpty() && IsValidDestination(dest) && std::get_if<PKHash>(&dest) == nullptr) {
+        ui->addressText->setStyleSheet(STYLE_INVALID);
+        showMessage(tr("Warning: Address must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported for asset operations."));
+        return;
+    }
+
     if (type == IntFromAssetType(AssetType::RESTRICTED)) {
 
         QString qVerifier = ui->lineEditVerifierString->text();

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -175,6 +175,8 @@ bool SendAssetsEntry::validate()
     if (!model->validateLegacyAddress(ui->payTo->text()))
     {
         ui->payTo->setValid(false);
+        ui->messageTextLabel->show();
+        ui->messageTextLabel->setText(tr("Address must use legacy (P2PKH) format. SegWit and bech32 addresses are not supported for asset transfers."));
         retval = false;
     }
 


### PR DESCRIPTION
This pull request introduces stricter validation and clearer user feedback for address formats in asset-related dialogs. The main goal is to ensure that only legacy (P2PKH) addresses are used for asset operations and to provide users with immediate warnings when unsupported address types are entered. Additionally, the asset list is now refreshed when the model is set in the assets dialog.

**Address format validation and user feedback:**

* Added validation in `CreateAssetDialog::CheckFormState()` to detect and reject SegWit and bech32 addresses, displaying a warning and marking the address field as invalid.
* Updated `SendAssetsEntry::validate()` to show a clear error message when a non-legacy address is entered for asset transfers.

**UI behavior improvements:**

* Ensured that the asset list is refreshed in `AssetsDialog::setModel()` whenever the model is set, keeping the UI up-to-date.