### PR TITLE
Fix GetTarget crash for MinotaurX blocks with low difficulty

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -269,7 +269,7 @@ static bool rest_headers(const std::any& context,
     case RESTResponseFormat::JSON: {
         UniValue jsonHeaders(UniValue::VARR);
         for (const CBlockIndex *pindex : headers) {
-            jsonHeaders.push_back(blockheaderToJSON(*tip, *pindex, chainman.GetConsensus().powLimit));
+            jsonHeaders.push_back(blockheaderToJSON(*tip, *pindex, chainman.GetConsensus()));
         }
         std::string strJSON = jsonHeaders.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
@@ -449,7 +449,7 @@ static bool rest_block(const std::any& context,
         CBlock block{};
         DataStream block_stream{block_data};
         block_stream >> TX_WITH_WITNESS(block);
-        UniValue objBlock = blockToJSON(chainman.m_blockman, block, *tip, *pblockindex, tx_verbosity, chainman.GetConsensus().powLimit);
+        UniValue objBlock = blockToJSON(chainman.m_blockman, block, *tip, *pblockindex, tx_verbosity, chainman.GetConsensus());
         std::string strJSON = objBlock.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -165,7 +165,7 @@ static const CBlockIndex* ParseHashOrHeight(const UniValue& param, ChainstateMan
     }
 }
 
-UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex, const uint256 pow_limit)
+UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex, const Consensus::Params& params)
 {
     // Serialize passed information without accessing chain state of the active chain!
     AssertLockNotHeld(cs_main); // For performance reasons
@@ -183,7 +183,7 @@ UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex
     result.pushKV("mediantime", blockindex.GetMedianTimePast());
     result.pushKV("nonce", blockindex.nNonce);
     result.pushKV("bits", strprintf("%08x", blockindex.nBits));
-    result.pushKV("target", GetTarget(blockindex, pow_limit).GetHex());
+    result.pushKV("target", GetTarget(blockindex, params).GetHex());
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex.nChainWork.GetHex());
     result.pushKV("nTx", blockindex.nTx);
@@ -195,9 +195,9 @@ UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex
     return result;
 }
 
-UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIndex& tip, const CBlockIndex& blockindex, TxVerbosity verbosity, const uint256 pow_limit)
+UniValue blockToJSON(BlockManager& blockman, const CBlock& block, const CBlockIndex& tip, const CBlockIndex& blockindex, TxVerbosity verbosity, const Consensus::Params& params)
 {
-    UniValue result = blockheaderToJSON(tip, blockindex, pow_limit);
+    UniValue result = blockheaderToJSON(tip, blockindex, params);
 
     result.pushKV("strippedsize", (int)::GetSerializeSize(TX_NO_WITNESS(block)));
     result.pushKV("size", (int)::GetSerializeSize(TX_WITH_WITNESS(block)));
@@ -680,7 +680,7 @@ static RPCHelpMan getblockheader()
         return strHex;
     }
 
-    return blockheaderToJSON(*tip, *pblockindex, chainman.GetConsensus().powLimit);
+    return blockheaderToJSON(*tip, *pblockindex, chainman.GetConsensus());
 },
     };
 }
@@ -888,7 +888,7 @@ static RPCHelpMan getblock()
         tx_verbosity = TxVerbosity::SHOW_DETAILS_AND_PREVOUT;
     }
 
-    return blockToJSON(chainman.m_blockman, block, *tip, *pblockindex, tx_verbosity, chainman.GetConsensus().powLimit);
+    return blockToJSON(chainman.m_blockman, block, *tip, *pblockindex, tx_verbosity, chainman.GetConsensus());
 },
     };
 }
@@ -1431,7 +1431,7 @@ RPCHelpMan getblockchaininfo()
     obj.pushKV("headers", chainman.m_best_header ? chainman.m_best_header->nHeight : -1);
     obj.pushKV("bestblockhash", tip.GetBlockHash().GetHex());
     obj.pushKV("bits", strprintf("%08x", tip.nBits));
-    obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
+    obj.pushKV("target", GetTarget(tip, chainman.GetConsensus()).GetHex());
     obj.pushKV("difficulty", GetDifficulty(tip));
     if (IsDualAlgoEnabled(&tip, chainman.GetConsensus())) {
         obj.pushKV("difficulty_minotaurx", GetDifficulty(POW_TYPE_MINOTAURX, active_chainstate.m_chain));
@@ -3489,7 +3489,7 @@ return RPCHelpMan{
         data.pushKV("blocks",                (int)chain.Height());
         data.pushKV("bestblockhash",         tip->GetBlockHash().GetHex());
         data.pushKV("bits", strprintf("%08x", tip->nBits));
-        data.pushKV("target", GetTarget(*tip, chainman.GetConsensus().powLimit).GetHex());
+        data.pushKV("target", GetTarget(*tip, chainman.GetConsensus()).GetHex());
         data.pushKV("difficulty", GetDifficulty(*tip));
         if (IsDualAlgoEnabled(tip, chainman.GetConsensus())) {
             data.pushKV("difficulty_minotaurx", GetDifficulty(POW_TYPE_MINOTAURX, chain));

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -43,10 +43,10 @@ const CBlockIndex* GetLastBlockIndex4Algo(const CBlockIndex* pindex, POW_TYPE po
 double GetDifficulty(POW_TYPE powType, const CChain& active_chain);
 
 /** Block description to JSON */
-UniValue blockToJSON(node::BlockManager& blockman, const CBlock& block, const CBlockIndex& tip, const CBlockIndex& blockindex, TxVerbosity verbosity, const uint256 pow_limit) LOCKS_EXCLUDED(cs_main);
+UniValue blockToJSON(node::BlockManager& blockman, const CBlock& block, const CBlockIndex& tip, const CBlockIndex& blockindex, TxVerbosity verbosity, const Consensus::Params& params) LOCKS_EXCLUDED(cs_main);
 
 /** Block header to JSON */
-UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex, const uint256 pow_limit) LOCKS_EXCLUDED(cs_main);
+UniValue blockheaderToJSON(const CBlockIndex& tip, const CBlockIndex& blockindex, const Consensus::Params& params) LOCKS_EXCLUDED(cs_main);
 
 /** Used by getblockstats to get feerates at different percentiles by weight  */
 void CalculatePercentilesByWeight(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES], std::vector<std::pair<CAmount, int64_t>>& scores, int64_t total_weight);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -634,7 +634,7 @@ static RPCHelpMan getmininginfo()
         obj.pushKV("difficulty_minotaurx", GetDifficulty(POW_TYPE_MINOTAURX, active_chain));
         obj.pushKV("difficulty_x16rt", GetDifficulty(POW_TYPE_X16RT, active_chain));
     }
-    obj.pushKV("target", GetTarget(tip, chainman.GetConsensus().powLimit).GetHex());
+    obj.pushKV("target", GetTarget(tip, chainman.GetConsensus()).GetHex());
     obj.pushKV("networkhashps",    getnetworkhashps().HandleRequest(request));
     if (IsDualAlgoEnabled(&tip, chainman.GetConsensus())) {
         obj.pushKV("networkhashps_minotaurx", GetNetworkHashPS(120, -1, active_chain, POW_TYPE_MINOTAURX));
@@ -657,7 +657,7 @@ static RPCHelpMan getmininginfo()
         next.pushKV("difficulty_minotaurx", GetDifficulty(POW_TYPE_MINOTAURX, active_chain));
         next.pushKV("difficulty_x16rt", GetDifficulty(POW_TYPE_X16RT, active_chain));
     }
-    next.pushKV("target", GetTarget(next_index, chainman.GetConsensus().powLimit).GetHex());
+    next.pushKV("target", GetTarget(next_index, chainman.GetConsensus()).GetHex());
     obj.pushKV("next", next);
 
     if (chainman.GetParams().GetChainType() == ChainType::SIGNET) {

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1412,8 +1412,21 @@ std::vector<RPCResult> ScriptPubKeyDoc() {
          };
 }
 
-uint256 GetTarget(const CBlockIndex& blockindex, const uint256 pow_limit)
+uint256 GetTarget(const CBlockIndex& blockindex, const Consensus::Params& params)
 {
-    arith_uint256 target{*CHECK_NONFATAL(DeriveTarget(blockindex.nBits, pow_limit))};
+    // Select the correct PoW limit based on algorithm: post-fork blocks encode
+    // the algorithm in nVersion bits [23:16], matching CheckProofOfWorkFromIndex.
+    uint256 limit;
+    if (params.powForkTime > 0 && blockindex.nTime > params.powForkTime) {
+        unsigned int powTypeIndex = (blockindex.nVersion >> 16) & 0xFF;
+        if (powTypeIndex < params.powTypeLimits.size()) {
+            limit = params.powTypeLimits[powTypeIndex];
+        } else {
+            limit = params.powLimit; // fallback for unrecognised algorithm
+        }
+    } else {
+        limit = params.powLimit;
+    }
+    arith_uint256 target{*CHECK_NONFATAL(DeriveTarget(blockindex.nBits, limit))};
     return ArithToUint256(target);
 }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -7,6 +7,7 @@
 
 #include <addresstype.h>
 #include <consensus/amount.h>
+#include <consensus/params.h>
 #include <node/transaction.h>
 #include <outputtype.h>
 #include <pubkey.h>
@@ -521,12 +522,13 @@ std::vector<RPCResult> ScriptPubKeyDoc();
 
 /***
  * Get the target for a given block index.
+ * Automatically selects the correct per-algorithm PoW limit for dual-algo blocks.
  *
  * @param[in] blockindex    the block
- * @param[in] pow_limit     PoW limit (consensus parameter)
+ * @param[in] params        consensus parameters
  *
  * @return  the target
  */
-uint256 GetTarget(const CBlockIndex& blockindex, const uint256 pow_limit);
+uint256 GetTarget(const CBlockIndex& blockindex, const Consensus::Params& params);
 
 #endif // BITCOIN_RPC_UTIL_H


### PR DESCRIPTION
This pull request refactors how the Proof-of-Work (PoW) target is determined and passed through the codebase, improving support for networks with multiple PoW algorithms. Instead of passing a single PoW limit, the code now passes the full consensus parameters, allowing the correct PoW limit to be selected based on the block's algorithm. This change touches several RPC and REST endpoints, as well as internal utility functions.

**Consensus parameter refactor for PoW target handling:**

* The `GetTarget` function now takes `Consensus::Params` instead of a single PoW limit, enabling automatic selection of the correct PoW limit for dual-algo (or multi-algo) blocks. The implementation checks the block version and time to determine the appropriate limit. [[1]](diffhunk://#diff-647c2f0c4261e4ba2bbfc487178f54f4702ad284b52c1ed2dbbd30a53a5ad487L1415-R1430) [[2]](diffhunk://#diff-f45c4d41804da60d58d1ca24b524ea5c7d96dff39fca7928676dcfb8a317000aR525-R532)
* All related functions (`blockheaderToJSON`, `blockToJSON`) and their call sites are updated to accept and forward `Consensus::Params` instead of a single PoW limit. This includes changes in both function signatures and usage throughout the codebase. [[1]](diffhunk://#diff-8a73a99cdf166cf6bdcba3423497f6519109e5a735e28edf1b7bc54a3da43b43L46-R49) [[2]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bL168-R168) [[3]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bL198-R200) [[4]](diffhunk://#diff-590507deaf686d6571f73979df5f3c6da6013a13e597f390b8facce39f7c69d1L272-R272) [[5]](diffhunk://#diff-590507deaf686d6571f73979df5f3c6da6013a13e597f390b8facce39f7c69d1L452-R452)

**RPC and REST endpoint updates:**

* All RPC and REST endpoints that previously called `GetTarget` or related functions with a PoW limit now pass the full consensus parameters, ensuring accurate target calculation for all supported algorithms. This affects endpoints such as `getblock`, `getblockheader`, `getblockchaininfo`, and `getmininginfo`. [[1]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bL683-R683) [[2]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bL891-R891) [[3]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bL1434-R1434) [[4]](diffhunk://#diff-decae4be02fb8a47ab4557fe74a9cb853bdfa3ec0fa1b515c0a1e5de91f4ad0bL3492-R3492) [[5]](diffhunk://#diff-ccc24453c13307f815879738d3bf00eec351417537fbf10dde1468180cacd2f1L637-R637) [[6]](diffhunk://#diff-ccc24453c13307f815879738d3bf00eec351417537fbf10dde1468180cacd2f1L660-R660)

**Documentation and header updates:**

* The documentation in `rpc/util.h` is updated to clarify that `GetTarget` now selects the correct per-algorithm PoW limit automatically. The header includes are also updated to import the consensus parameters. [[1]](diffhunk://#diff-f45c4d41804da60d58d1ca24b524ea5c7d96dff39fca7928676dcfb8a317000aR10) [[2]](diffhunk://#diff-f45c4d41804da60d58d1ca24b524ea5c7d96dff39fca7928676dcfb8a317000aR525-R532)