### PR TITLE
fix: calibrate block-count constants for Avian 30-second block time

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -45,10 +45,11 @@ static constexpr int64_t TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME;
 /**
  * Maximum gap between node time and block time used
  * for the "Catching up..." mode in GUI.
+ * Avian: 9 blocks at 30-second block time = 270 seconds (vs Bitcoin's 90 minutes).
  *
  * Ref: https://github.com/bitcoin/bitcoin/pull/1026
  */
-static constexpr int64_t MAX_BLOCK_TIME_GAP = 90 * 60;
+static constexpr int64_t MAX_BLOCK_TIME_GAP = 9 * 30;
 
 class CBlockFileInfo
 {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -149,10 +149,12 @@ static constexpr double BLOCK_DOWNLOAD_TIMEOUT_BASE = 1;
 static constexpr double BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 0.5;
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
-/** Minimum blocks required to signal NODE_NETWORK_LIMITED */
-static const unsigned int NODE_NETWORK_LIMITED_MIN_BLOCKS = 288;
-/** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers */
-static const unsigned int NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS = 144;
+/** Minimum blocks required to signal NODE_NETWORK_LIMITED.
+ * Avian: 5760 blocks = ~2 days at 30-second block time (equivalent to Bitcoin's 288 blocks @ 10 min) */
+static const unsigned int NODE_NETWORK_LIMITED_MIN_BLOCKS = 5760;
+/** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers.
+ * Avian: 2880 blocks = ~1 day at 30-second block time (equivalent to Bitcoin's 144 blocks @ 10 min) */
+static const unsigned int NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS = 2880;
 /** Average delay between local address broadcasts */
 static constexpr auto AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL{24h};
 /** Average delay between peer address broadcasts */

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -157,15 +157,16 @@ private:
     /** Track confirm delays up to 1008 blocks for long horizon */
     static constexpr unsigned int LONG_BLOCK_PERIODS = 42;
     static constexpr unsigned int LONG_SCALE = 24;
-    /** Historical estimates that are older than this aren't valid */
-    static const unsigned int OLDEST_ESTIMATE_HISTORY = 6 * 1008;
+    /** Historical estimates that are older than this aren't valid.
+     * Avian: 120960 blocks = ~6 weeks at 30-second block time */
+    static const unsigned int OLDEST_ESTIMATE_HISTORY = 6 * 20160;
 
-    /** Decay of .962 is a half-life of 18 blocks or about 3 hours */
-    static constexpr double SHORT_DECAY = .962;
-    /** Decay of .9952 is a half-life of 144 blocks or about 1 day */
-    static constexpr double MED_DECAY = .9952;
-    /** Decay of .99931 is a half-life of 1008 blocks or about 1 week */
-    static constexpr double LONG_DECAY = .99931;
+    /** Decay of .9981 is a half-life of 360 blocks or about 3 hours (Avian: 30s blocks) */
+    static constexpr double SHORT_DECAY = .9981;
+    /** Decay of .99976 is a half-life of 2880 blocks or about 1 day (Avian: 30s blocks) */
+    static constexpr double MED_DECAY = .99976;
+    /** Decay of .999966 is a half-life of 20160 blocks or about 1 week (Avian: 30s blocks) */
+    static constexpr double LONG_DECAY = .999966;
 
     /** Require greater than 60% of X feerate transactions to be confirmed within Y/2 blocks*/
     static constexpr double HALF_SUCCESS_PCT = .6;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1404,6 +1404,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     tooltip = tr("Processed %n block(s) of transaction history.", "", count);
 
     // Set icon state: spinning if catching up, tick otherwise
+    // MAX_BLOCK_TIME_GAP is calibrated to Avian's 30-second block time (9 blocks = 270s)
     if (secs < MAX_BLOCK_TIME_GAP) {
         tooltip = tr("Up to date") + QString(".<br>") + tooltip;
         labelBlocksIcon->setThemedPixmap(QStringLiteral(":/icons/synced"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1535,8 +1535,8 @@ void CWallet::blockConnected(ChainstateRole role, const interfaces::BlockInfo& b
         transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
     }
 
-    // Update on disk if this block resulted in us updating a tx, or periodically every 144 blocks (~1 day)
-    if (wallet_updated || block.height % 144 == 0) {
+    // Update on disk if this block resulted in us updating a tx, or periodically every 2880 blocks (~1 day at 30s Avian block time)
+    if (wallet_updated || block.height % 2880 == 0) {
         WriteBestBlock();
     }
 }


### PR DESCRIPTION
Scale Bitcoin-era constants (calibrated for 10-minute blocks) to their wall-clock equivalents for Avian's 30-second block time (x20 factor):

- policy/fees.h: rescale fee estimator decay half-lives and history window (SHORT_DECAY, MED_DECAY, LONG_DECAY, OLDEST_ESTIMATE_HISTORY)
- wallet/wallet.cpp: wallet flush period 144 -> 2880 blocks (~1 day)
- chain.h: MAX_BLOCK_TIME_GAP 5400s -> 270s (9 blocks at 30s each)
- qt/bitcoingui.cpp: clarifying comment on MAX_BLOCK_TIME_GAP
- net_processing.cpp: NODE_NETWORK_LIMITED thresholds 288/144 ->
  5760/2880 blocks (~2 days / ~1 day); safe since NODE_NETWORK_LIMITED is new in v5 and absent from v4.2 nodes entirely