### PR TITLE
fix: ReindexAssets - clean rebuild, UTXO flush, and UI progress

### DIFF
--- a/src/assets/assetdb.cpp
+++ b/src/assets/assetdb.cpp
@@ -126,6 +126,25 @@ bool CAssetsDB::ReadReissuedMempoolState(std::map<std::string, uint256>& mapReis
     return rv;
 }
 
+bool CAssetsDB::EraseAllAssets()
+{
+    // Erase all ASSET_FLAG ('A') entries (asset metadata).
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+
+    pcursor->Seek(std::make_pair(ASSET_FLAG, std::string()));
+    while (pcursor->Valid()) {
+        std::pair<uint8_t, std::string> key;
+        if (pcursor->GetKey(key) && key.first == ASSET_FLAG) {
+            Erase(std::make_pair(ASSET_FLAG, key.second));
+            pcursor->Next();
+        } else {
+            break;
+        }
+    }
+
+    return true;
+}
+
 bool CAssetsDB::EraseAllAddressQuantities()
 {
     // Erase all ASSET_ADDRESS_QUANTITY_FLAG ('B') and ADDRESS_ASSET_QUANTITY_FLAG ('C') entries.

--- a/src/assets/assetdb.h
+++ b/src/assets/assetdb.h
@@ -107,6 +107,7 @@ public:
     bool EraseAssetAddressQuantity(const std::string &assetName, const std::string &address);
     bool EraseAddressAssetQuantity(const std::string &address, const std::string &assetName);
     bool EraseAllAddressQuantities();
+    bool EraseAllAssets();
 
     // Helper functions
     bool LoadAssets(class CLRUCache<std::string, CDatabasedAssetData>& cache,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -7321,9 +7321,11 @@ bool ReindexAssets(ChainstateManager& chainman)
         return true;
     }
 
-    // Erase only the address-balance keys ('B'/'C'). Asset metadata ('A' keys)
-    // is preserved if present, and rebuilt in Phase 1 below if missing.
+    // Erase all asset DB keys so both phases start from a known-clean state:
+    // Phase 1 rebuilds 'A' (metadata) from blocks; Phase 2 rebuilds 'B'/'C'
+    // (address balances) from the UTXO set.
     if (passetsdb) {
+        passetsdb->EraseAllAssets();
         passetsdb->EraseAllAddressQuantities();
     }
 
@@ -7343,6 +7345,7 @@ bool ReindexAssets(ChainstateManager& chainman)
     // append-only from the chain's perspective. Transfers don't affect metadata.
     // -----------------------------------------------------------------------
     LogPrintf("ReindexAssets: Phase 1 — rebuilding asset metadata from %d blocks...\n", tip_height);
+    chainman.GetNotifications().progress(_("Rebuilding asset database (step 1/2)…"), 0, false);
 
     const int metadata_log_interval = 10000;
     int blocks_processed = 0;
@@ -7350,6 +7353,7 @@ bool ReindexAssets(ChainstateManager& chainman)
     for (int height = 1; height <= tip_height; height++) {
         if (chainman.m_interrupt) {
             LogPrintf("ReindexAssets: Interrupted at height %d during metadata pass\n", height);
+            chainman.GetNotifications().progress(bilingual_str{}, 100, false);
             return false;
         }
 
@@ -7441,11 +7445,14 @@ bool ReindexAssets(ChainstateManager& chainman)
         blocks_processed++;
 
         if (blocks_processed % metadata_log_interval == 0) {
+            int pct = (int)(50.0 * height / tip_height); // phase 1 = 0..50%
             LogPrintf("ReindexAssets: Phase 1 — processed %d/%d blocks (%.1f%%)\n",
                       height, tip_height, 100.0 * height / tip_height);
+            chainman.GetNotifications().progress(_("Rebuilding asset database (step 1/2)…"), pct, false);
             // Periodically flush metadata to DB to bound memory usage.
             if (!passets->DumpCacheToDatabase()) {
                 LogError("ReindexAssets: Failed to flush metadata at height %d\n", height);
+                chainman.GetNotifications().progress(bilingual_str{}, 100, false);
                 return false;
             }
         }
@@ -7473,6 +7480,13 @@ bool ReindexAssets(ChainstateManager& chainman)
     // unspent outputs, so scanning it gives correct current balances directly.
     // -----------------------------------------------------------------------
     LogPrintf("ReindexAssets: Phase 2 — rebuilding address balances from UTXO set...\n");
+    chainman.GetNotifications().progress(_("Rebuilding asset database (step 2/2)…"), 50, false);
+
+    // Flush the in-memory UTXO tip cache to disk so the cursor below sees
+    // the complete UTXO set. Without this, UTXOs written since the last
+    // periodic flush (e.g. at the end of ImportBlocks) would be invisible
+    // to CoinsDB().Cursor(), producing empty or partial balances.
+    active_chainstate.ForceFlushStateToDisk();
 
     std::unique_ptr<CCoinsViewCursor> pcursor(active_chainstate.CoinsDB().Cursor());
     if (!pcursor) {
@@ -7531,6 +7545,7 @@ bool ReindexAssets(ChainstateManager& chainman)
         if (pTip) passetsdb->WriteBestBlock(pTip->GetBlockHash());
     }
 
+    chainman.GetNotifications().progress(bilingual_str{}, 100, false);
     LogPrintf("ReindexAssets: Complete — metadata rebuilt from blocks, %d address balances from UTXO set.\n",
               (int)mapBalances.size());
     return true;


### PR DESCRIPTION
- Add CAssetsDB::EraseAllAssets() to wipe all 'A' metadata keys before phase 1; prevents 'already existed' errors when reindexing over an existing asset DB
- Call ForceFlushStateToDisk() before the phase 2 UTXO cursor scan so UTXOs still in the in-memory CoinsTip() cache are visible to the DB cursor; without this, balances were empty after a fresh sync
- Add GetNotifications().progress() calls throughout both phases so the GUI loading screen shows 'Rebuilding asset database (step 1/2)' and 'Rebuilding asset database (step 2/2)' with % progress instead of staying frozen