### PR TITLE
fix(index): correct P2PKH script byte index [22]->[23] in address ind…

### DIFF
--- a/src/rpc/indexes.cpp
+++ b/src/rpc/indexes.cpp
@@ -233,7 +233,7 @@ static RPCHelpMan getaddressutxos()
                 throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
 
             bool includeChainInfo = false;
-            std::string assetName = AVN;
+            std::string assetName = "*";  // default: return all UTXOs (native coin + assets)
             int limit = 0;
             int offset = 0;
 
@@ -243,7 +243,7 @@ static RPCHelpMan getaddressutxos()
 
                 const UniValue& assetNameParam = request.params[0]["assetName"];
                 if (assetNameParam.isStr()) {
-                    if (!AreAssetsDeployed())
+                    if (assetNameParam.get_str() != "*" && !AreAssetsDeployed())
                         throw JSONRPCError(RPC_INVALID_PARAMETER, "Assets aren't active.");
                     assetName = assetNameParam.get_str();
                 }
@@ -368,10 +368,10 @@ static RPCHelpMan getaddressdeltas()
             const UniValue& chainInfo = request.params[0]["chainInfo"];
             if (chainInfo.isBool()) includeChainInfo = chainInfo.get_bool();
 
-            std::string assetName = AVN;
+            std::string assetName = "*";  // default: return all deltas (native coin + assets)
             const UniValue& assetNameParam = request.params[0]["assetName"];
             if (assetNameParam.isStr()) {
-                if (!AreAssetsDeployed())
+                if (assetNameParam.get_str() != "*" && !AreAssetsDeployed())
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Assets aren't active.");
                 assetName = assetNameParam.get_str();
             }
@@ -398,12 +398,22 @@ static RPCHelpMan getaddressdeltas()
 
             std::vector<std::pair<CAddressIndexKey, CAmount>> addressIndex;
             for (const auto& [addrHash, addrType] : addresses) {
-                if (start > 0 && end > 0) {
-                    if (!GetAddressIndex(addrHash, addrType, assetName, addressIndex, start, end))
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+                if (assetName == "*") {
+                    if (start > 0 && end > 0) {
+                        if (!GetAddressIndex(addrHash, addrType, addressIndex, start, end))
+                            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+                    } else {
+                        if (!GetAddressIndex(addrHash, addrType, addressIndex))
+                            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+                    }
                 } else {
-                    if (!GetAddressIndex(addrHash, addrType, assetName, addressIndex))
-                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+                    if (start > 0 && end > 0) {
+                        if (!GetAddressIndex(addrHash, addrType, assetName, addressIndex, start, end))
+                            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+                    } else {
+                        if (!GetAddressIndex(addrHash, addrType, assetName, addressIndex))
+                            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+                    }
                 }
             }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -555,7 +555,7 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewC
             CMempoolAddressDelta delta(entryTime, prevout.nValue * -1, input.prevout.hash.ToUint256(), input.prevout.n);
             mapAddress.insert(std::make_pair(key, delta));
             inserted.push_back(key);
-        } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[22] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
+        } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[23] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
             std::vector<unsigned char> hashBytes(prevScript.begin()+3, prevScript.begin()+23);
             CMempoolAddressDeltaKey key(1, uint160(hashBytes), AVN, txhash, j, 1);
             CMempoolAddressDelta delta(entryTime, prevout.nValue * -1, input.prevout.hash.ToUint256(), input.prevout.n);
@@ -591,7 +591,7 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewC
             CMempoolAddressDeltaKey key(2, uint160(hashBytes), AVN, txhash, k, 0);
             mapAddress.insert(std::make_pair(key, CMempoolAddressDelta(entryTime, out.nValue)));
             inserted.push_back(key);
-        } else if (outScript.size() == 25 && outScript[0] == OP_DUP && outScript[1] == OP_HASH160 && outScript[2] == 20 && outScript[22] == OP_EQUALVERIFY && outScript[24] == OP_CHECKSIG) {
+        } else if (outScript.size() == 25 && outScript[0] == OP_DUP && outScript[1] == OP_HASH160 && outScript[2] == 20 && outScript[23] == OP_EQUALVERIFY && outScript[24] == OP_CHECKSIG) {
             std::vector<unsigned char> hashBytes(outScript.begin()+3, outScript.begin()+23);
             CMempoolAddressDeltaKey key(1, uint160(hashBytes), AVN, txhash, k, 0);
             mapAddress.insert(std::make_pair(key, CMempoolAddressDelta(entryTime, out.nValue)));
@@ -677,7 +677,7 @@ void CTxMemPool::addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCac
         if (prevScript.IsPayToScriptHash()) {
             addressHash = uint160(std::vector<unsigned char>(prevScript.begin()+2, prevScript.begin()+22));
             addressType = 2;
-        } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[22] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
+        } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[23] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
             addressHash = uint160(std::vector<unsigned char>(prevScript.begin()+3, prevScript.begin()+23));
             addressType = 1;
         } else if ((prevScript.size() == 35 || prevScript.size() == 67) && prevScript[prevScript.size()-1] == OP_CHECKSIG) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2466,7 +2466,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
                 if (outScript.IsPayToScriptHash()) {
                     addressType = 2;
                     hashBytes = uint160(std::vector<unsigned char>(outScript.begin()+2, outScript.begin()+22));
-                } else if (outScript.size() == 25 && outScript[0] == OP_DUP && outScript[1] == OP_HASH160 && outScript[2] == 20 && outScript[22] == OP_EQUALVERIFY && outScript[24] == OP_CHECKSIG) {
+                } else if (outScript.size() == 25 && outScript[0] == OP_DUP && outScript[1] == OP_HASH160 && outScript[2] == 20 && outScript[23] == OP_EQUALVERIFY && outScript[24] == OP_CHECKSIG) {
                     addressType = 1;
                     hashBytes = uint160(std::vector<unsigned char>(outScript.begin()+3, outScript.begin()+23));
                 } else if ((outScript.size() == 35 || outScript.size() == 67) && outScript[outScript.size()-1] == OP_CHECKSIG) {
@@ -2560,7 +2560,7 @@ DisconnectResult Chainstate::DisconnectBlock(const CBlock& block, const CBlockIn
                     if (prevScript.IsPayToScriptHash()) {
                         addressType = 2;
                         hashBytes = uint160(std::vector<unsigned char>(prevScript.begin()+2, prevScript.begin()+22));
-                    } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[22] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
+                    } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[23] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
                         addressType = 1;
                         hashBytes = uint160(std::vector<unsigned char>(prevScript.begin()+3, prevScript.begin()+23));
                     } else if ((prevScript.size() == 35 || prevScript.size() == 67) && prevScript[prevScript.size()-1] == OP_CHECKSIG) {
@@ -3200,7 +3200,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                     if (prevScript.IsPayToScriptHash()) {
                         addressType = 2;
                         hashBytes = uint160(std::vector<unsigned char>(prevScript.begin()+2, prevScript.begin()+22));
-                    } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[22] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
+                    } else if (prevScript.size() == 25 && prevScript[0] == OP_DUP && prevScript[1] == OP_HASH160 && prevScript[2] == 20 && prevScript[23] == OP_EQUALVERIFY && prevScript[24] == OP_CHECKSIG) {
                         addressType = 1;
                         hashBytes = uint160(std::vector<unsigned char>(prevScript.begin()+3, prevScript.begin()+23));
                     } else if ((prevScript.size() == 35 || prevScript.size() == 67) && prevScript[prevScript.size()-1] == OP_CHECKSIG) {
@@ -3267,7 +3267,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                 if (outScript.IsPayToScriptHash()) {
                     addressType = 2;
                     hashBytes = uint160(std::vector<unsigned char>(outScript.begin()+2, outScript.begin()+22));
-                } else if (outScript.size() == 25 && outScript[0] == OP_DUP && outScript[1] == OP_HASH160 && outScript[2] == 20 && outScript[22] == OP_EQUALVERIFY && outScript[24] == OP_CHECKSIG) {
+                } else if (outScript.size() == 25 && outScript[0] == OP_DUP && outScript[1] == OP_HASH160 && outScript[2] == 20 && outScript[23] == OP_EQUALVERIFY && outScript[24] == OP_CHECKSIG) {
                     addressType = 1;
                     hashBytes = uint160(std::vector<unsigned char>(outScript.begin()+3, outScript.begin()+23));
                 } else if ((outScript.size() == 35 || outScript.size() == 67) && outScript[outScript.size()-1] == OP_CHECKSIG) {


### PR DESCRIPTION
The P2PKH script pattern check used script[22] == OP_EQUALVERIFY, but byte [22] is the last byte of the 20-byte hash160 payload. OP_EQUALVERIFY is at byte [23]. This caused ~99.6% of all P2PKH outputs to be silently skipped when building the address index in ConnectBlock, DisconnectBlock, and the mempool address index.

Also fix getaddressutxos and getaddressdeltas RPC defaults from AVN-only to '*' (all assets) so P2PKH-only addresses return results correctly.

Affected sites:
- src/validation.cpp: DisconnectBlock outputs/inputs, ConnectBlock inputs/outputs (4 sites)
- src/txmempool.cpp: addAddressIndex inputs/outputs, addSpentIndex (3 sites)
- src/rpc/indexes.cpp: getaddressutxos, getaddressdeltas default assetName