### PR TITLE
Add missing CheckTxAssets and pre-activation guard to mempool acceptance

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -944,6 +944,26 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return false; // state filled in by CheckTxInputs
     }
 
+    /** AVN START - Reject asset scripts before activation & validate asset consensus rules */
+    if (!AreAssetsDeployed()) {
+        for (const auto& out : tx.vout) {
+            if (out.scriptPubKey.IsAssetScript()) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-contained-asset-when-not-active");
+            }
+        }
+    }
+
+    if (AreAssetsDeployed() && !tx.IsCoinBase()) {
+        CAssetsCache* currentAssetCache = GetCurrentAssetCache();
+        if (currentAssetCache) {
+            std::vector<std::pair<std::string, uint256>> vReissueAssets;
+            if (!Consensus::CheckTxAssets(tx, state, m_view, currentAssetCache, &m_pool, vReissueAssets)) {
+                return false; // state filled in by CheckTxAssets
+            }
+        }
+    }
+    /** AVN END */
+
     if (m_pool.m_opts.require_standard && !AreInputsStandard(tx, m_view)) {
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs");
     }


### PR DESCRIPTION
In the v5.0.0 rebase onto Bitcoin Core 30.2, two asset validation checks were lost from the mempool acceptance path (MemPoolAccept::PreChecks):

1. Pre-activation guard: reject transactions containing asset scripts before assets are deployed (bad-txns-contained-asset-when-not-active).

2. Consensus::CheckTxAssets call: validate asset operations (amounts, ownership, names, reissue rules) during mempool acceptance. Without this, invalid asset transactions could enter the mempool and propagate to peers before being rejected at block connection time.

Both checks existed in v4.2.0's AcceptToMemoryPoolWorker and are restored after CheckTxInputs where input coins are cached in m_view.