### PR TITLE
consensus: restore asset structural-validation layer (burn/owner/count checks) + wallet owner-token fix

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -366,6 +366,15 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, TxValidationState& state, 
 
     if (assetCache) {
         if (IsNewAsset(tx)) {
+            // Restore the structural validation layer that 4.2.0 runs in CheckTransaction but the
+            // Bitcoin Core 30.2 rewrite left as dead code (VerifyNewAsset had no call sites in 5.x).
+            // It enforces the issuance burn, that the owner-token name matches the asset, the output
+            // counts, and — for sub-assets — that the parent ROOT! owner token is held. Without it,
+            // 5.x accepted issuances with no burn / a mismatched owner / no parent owner that 4.2.0
+            // rejects, which both splits the chain and allows free/unauthorized issuance.
+            if (!VerifyNewAsset(tx, strError))
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
+
             CNewAsset asset;
             std::string address;
             if (!AssetFromScript(tx.vout[tx.vout.size() - 1].scriptPubKey, asset, address)) {
@@ -380,6 +389,13 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, TxValidationState& state, 
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
 
         } else if (IsReissueAsset(tx)) {
+            // Structural check (restored from 4.2.0): requires the NAME! owner-token transfer and the
+            // reissue burn output, and enforces the reissue output counts. Without it, 5.x let anyone
+            // reissue (mint more of) any reissuable asset they do NOT own, paying no burn — a
+            // consensus split and an unauthorized-inflation bug.
+            if (!VerifyReissueAsset(tx, strError))
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
+
             CReissueAsset reissue_asset;
             std::string address;
             if (!ReissueAssetFromScript(tx.vout[tx.vout.size() - 1].scriptPubKey, reissue_asset, address)) {
@@ -389,6 +405,12 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, TxValidationState& state, 
             if (!ContextualCheckReissueAsset(assetCache, reissue_asset, strError, tx))
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-reissue-contextual-" + strError);
         } else if (IsNewUniqueAsset(tx)) {
+            // Structural check (restored from 4.2.0): requires the 5-AVN unique burn and that the
+            // parent ROOT! owner token is held, and rejects any owner-token creation output. This
+            // subsumes the explicit owner-output guard below, which is kept for defence in depth.
+            if (!VerifyNewUniqueAsset(tx, strError))
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
+
             // Unique asset creation txs must NOT contain an owner token creation output
             // (TX_NEW_ASSET, fIsOwner=true). A unique asset has no owner token of its own; it
             // inherits authority from its parent root ROOT! owner, which is *transferred* (not newly
@@ -414,6 +436,10 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, TxValidationState& state, 
             if (!AreMessagesDeployed())
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-issue-msgchannel-before-messaging-is-active");
 
+            // Structural check (restored from 4.2.0): burn output present and output counts.
+            if (!VerifyNewMsgChannelAsset(tx, strError))
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
+
             CNewAsset asset;
             std::string strAddress;
             if (!MsgChannelAssetFromTransaction(tx, asset, strAddress))
@@ -424,6 +450,10 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, TxValidationState& state, 
         } else if (IsNewQualifierAsset(tx)) {
             if (!AreRestrictedAssetsDeployed())
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-issue-qualifier-before-it-is-active");
+
+            // Structural check (restored from 4.2.0): burn output present and output counts.
+            if (!VerifyNewQualfierAsset(tx, strError))
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
 
             CNewAsset asset;
             std::string strAddress;
@@ -436,6 +466,12 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, TxValidationState& state, 
         } else if (IsNewRestrictedAsset(tx)) {
             if (!AreRestrictedAssetsDeployed())
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-issue-restricted-before-it-is-active");
+
+            // Structural check (restored from 4.2.0): burn output present, output counts, and the
+            // root TOKEN! owner transfer. Subsumes the explicit owner-output guard below, which is
+            // kept for defence in depth.
+            if (!VerifyNewRestrictedAsset(tx, strError))
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, strError);
 
             // Restricted asset creation txs must NOT contain an owner token creation output (TX_NEW_ASSET, fIsOwner=true).
             // The root TOKEN! owner is transferred (not newly created) in these transactions. Any tx with an

--- a/src/wallet/asset_tx.cpp
+++ b/src/wallet/asset_tx.cpp
@@ -238,10 +238,14 @@ bool CreateAssetTransaction(
     //   must be pinned to position 0 so it cannot displace either of the last two outputs.
     CTxDestination assetDest = DecodeDestination(address);
     for (const auto& asset : assets) {
-        // Owner token output (will be second-to-last) — NOT for restricted assets.
-        // Restricted assets ($TOKEN) must NOT have an explicit $TOKEN! creation output;
-        // the validated transaction structure is: burn, ROOT! transfer, verifier, $TOKEN.
-        if (assetType != AssetType::RESTRICTED) {
+        // Owner token output (second-to-last) — ONLY root and sub assets get their own NAME! owner
+        // token. UNIQUE, MSGCHANNEL, QUALIFIER and RESTRICTED assets must NOT have an explicit owner
+        // creation output: uniques/qualifiers/msgchannels have no owner token at all, and a restricted
+        // $TOKEN is governed by the root TOKEN! owner (only transferred, section 4). Emitting an owner
+        // token for these types builds a transaction consensus rejects (VerifyNew*Asset: nOwners must
+        // be 0) — for uniques it caused the chain split. Was `!= RESTRICTED`, which wrongly created
+        // owner tokens for unique and message-channel issuance.
+        if (assetType == AssetType::ROOT || assetType == AssetType::SUB) {
             CScript scriptOwnerNew = GetScriptForDestination(assetDest);
             asset.ConstructOwnerTransaction(scriptOwnerNew);
 


### PR DESCRIPTION
Avian 4.2.0 validates assets in two consensus layers: CheckTransaction runs the structural Verify* validators (burn present, owner token present and correctly named, output counts, parent owner held), and CheckTxAssets runs the field/contextual checks. The Bitcoin Core 30.2 rewrite replaced CheckTransaction with stock consensus/tx_check.cpp, which has no asset logic, so every Verify* validator became dead code (zero call sites). Only the field layer survived. The unique-owner split was one symptom; the layer's absence also let 5.x accept, and 4.2.0 reject, transactions that:

- reissue (mint more of) any reissuable asset WITHOUT holding its owner token and WITHOUT paying the burn (unauthorized inflation);
- issue root/sub assets with no/incorrect burn, a mismatched owner token name, or (for sub) without the parent owner token;
- issue uniques with no 5-AVN burn or without the parent owner;
- issue restricted/qualifier/msgchannel assets with no burn.

Each is a chain-split vector, and several are inflation/theft bugs.

Re-wire the existing (unchanged) Verify* validators into the live CheckTxAssets dispatch, one per issuance/reissue branch. These are purely additive rejections: they can only make the malicious transactions invalid, never make a previously-invalid tx valid, and the canonical 4.2.0 chain already satisfies them. The explicit unique and restricted owner-output guards are kept for defence in depth.

Also fix wallet/asset_tx.cpp: the owner-token creation output was gated on assetType not-equal RESTRICTED, so the wallet/GUI built an illegal owner token for UNIQUE and MSGCHANNEL issuance (the same defect that split the chain; post-fix it would build-then-fail at broadcast). Restrict owner creation to ROOT and SUB only.

Lower-severity divergences found but NOT addressed here (separate follow-up, they need careful activation handling): the assets-active predicate (5.x node wall-clock vs 4.2.0 chain-tip block time) and ANS activation (BIP9 vs timestamp).
