### PR TITLE
build: open 5.0.5 development cycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,9 @@ get_directory_property(precious_variables CACHE_VARIABLES)
 set(CLIENT_NAME "Avian Core")
 set(CLIENT_VERSION_MAJOR 5)
 set(CLIENT_VERSION_MINOR 0)
-set(CLIENT_VERSION_BUILD 4)
+set(CLIENT_VERSION_BUILD 5)
 set(CLIENT_VERSION_RC 0)
-set(CLIENT_VERSION_IS_RELEASE "true")
+set(CLIENT_VERSION_IS_RELEASE "false")
 set(COPYRIGHT_YEAR "2026")
 
 # During the enabling of the CXX and CXXOBJ languages, we modify


### PR DESCRIPTION
`main` is currently pinned at 5.0.4 with `CLIENT_VERSION_IS_RELEASE="true"`, so any build off `main` reports itself as the released 5.0.4 even with post-release work on top.

This opens the 5.0.5 development cycle:

- `CLIENT_VERSION_BUILD` 4 -> 5
- `CLIENT_VERSION_IS_RELEASE` "true" -> "false"

Development builds now report `5.0.5-dev` and cannot be mistaken for the 5.0.4 release. The flag flips back to "true" when 5.0.5 is tagged.

Intended to merge before other post-5.0.4 work (such as the unit-test localization branch) so that work stacks on an opened dev cycle rather than on a release-tagged tree.