### PR TITLE
ci: split Build/Unit-tests, add Lint job, dedupe push/PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,15 @@ jobs:
         with:
           cache-provider: gha
 
-      - name: CI script
+      - name: Build
         run: ./ci/test_run_all.sh
+        env:
+          CI_PHASE: build
+
+      - name: Unit tests
+        run: ./ci/test_run_all.sh
+        env:
+          CI_PHASE: test
 
       - name: Collect Linux artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ on:
       - '**'
 
 concurrency:
-  # Group by workflow + ref so the push and pull_request events for the same branch
-  # share a group and the duplicate run is auto-cancelled (they used to land in
-  # separate groups and both run).
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Group by workflow + branch so the push and pull_request events for the same
+  # branch share a group and the duplicate run is auto-cancelled. head_ref is set
+  # for pull_request (the source branch); ref_name is the branch for push. Keying
+  # on github.ref instead would not work, because for pull_request it is
+  # refs/pull/N/merge rather than the branch.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.event_name != 'pull_request' && github.run_id || github.ref }}
+  # Group by workflow + ref so the push and pull_request events for the same branch
+  # share a group and the duplicate run is auto-cancelled (they used to land in
+  # separate groups and both run).
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -84,3 +87,24 @@ jobs:
 
       - name: Save caches
         uses: ./.github/actions/save-caches
+
+  lint:
+    name: 'Lint'
+    runs-on: ubuntu-24.04
+    if: ${{ vars.SKIP_BRANCH_PUSH != 'true' || github.event_name == 'pull_request' }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # Linters such as commit-range and the whitespace/newline checks need
+          # history beyond the tip.
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.ref || '' }}
+
+      - name: Build the lint image
+        run: docker build --tag avian-lint --file ci/lint_imagefile .
+
+      - name: Run linters
+        run: docker run --rm --volume "$(pwd):/avian" avian-lint

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -42,6 +42,12 @@ export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
 export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-false}
 export RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS:-false}
 export RUN_TIDY=${RUN_TIDY:-false}
+# Which phase of 03_test_script.sh to run: "build" (compile only), "test" (run tests
+# against an already-built tree), or "all" (both, the default). Splitting these lets the
+# workflow show Build and Unit tests as separate steps; the build tree persists between the
+# two container runs via the host-mounted BASE_BUILD_DIR. Exported so it is forwarded into
+# the container (02_run_container.py only passes vars that appear in an export line here).
+export CI_PHASE=${CI_PHASE:-all}
 # By how much to scale the test_runner timeouts (option --timeout-factor).
 # This is needed because some ci machines have slow CPU or disk, so sanitizers
 # might be slow or a reindex might be waiting on disk IO.

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -110,6 +110,12 @@ if [ "$DOWNLOAD_PREVIOUS_RELEASES" = "true" ]; then
   test/get_previous_releases.py --target-dir "$PREVIOUS_RELEASES_DIR"
 fi
 
+# --- Build phase -----------------------------------------------------------------------
+# Everything that produces the build tree. Skipped when CI_PHASE=test so the workflow can
+# run Build and Unit tests as separate steps; the build tree persists between the two
+# container runs via the host-mounted BASE_BUILD_DIR.
+if [ "${CI_PHASE}" != "test" ]; then
+
 AVIAN_CONFIG_ALL="-DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF"
 if [ -z "$NO_DEPENDS" ]; then
   AVIAN_CONFIG_ALL="${AVIAN_CONFIG_ALL} -DCMAKE_TOOLCHAIN_FILE=$DEPENDS_DIR/$HOST/toolchain.cmake"
@@ -155,6 +161,8 @@ fi
 du -sh "${DEPENDS_DIR}"/*/
 du -sh "${PREVIOUS_RELEASES_DIR}"
 
+fi  # --- end build phase (CI_PHASE != test) ---
+
 if [ -n "${CI_LIMIT_STACK_SIZE}" ]; then
   ulimit -s 512
 fi
@@ -167,7 +175,7 @@ if [ "$RUN_CHECK_DEPS" = "true" ]; then
   "${BASE_ROOT_DIR}/contrib/devtools/check-deps.sh" "${BASE_BUILD_DIR}"
 fi
 
-if [ "$RUN_UNIT_TESTS" = "true" ]; then
+if [ "$RUN_UNIT_TESTS" = "true" ] && [ "${CI_PHASE}" != "build" ]; then
   DIR_UNIT_TEST_DATA="${DIR_UNIT_TEST_DATA}" \
   LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \
   CTEST_OUTPUT_ON_FAILURE=ON \
@@ -177,7 +185,7 @@ if [ "$RUN_UNIT_TESTS" = "true" ]; then
     --timeout $(( TEST_RUNNER_TIMEOUT_FACTOR * 60 ))
 fi
 
-if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
+if [ "$RUN_FUNCTIONAL_TESTS" = "true" ] && [ "${CI_PHASE}" != "build" ]; then
   # parses TEST_RUNNER_EXTRA as an array which allows for multiple arguments such as TEST_RUNNER_EXTRA='--exclude "rpc_bind.py --ipv6"'
   eval "TEST_RUNNER_EXTRA=($TEST_RUNNER_EXTRA)"
   LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -1420,7 +1420,7 @@ bool IsNewRestrictedAsset(const CTransaction& tx)
 
 //! To be called on CTransactions where IsNewRestrictedAsset returns true
 bool VerifyNewRestrictedAsset(const CTransaction& tx, std::string& strError) {
-    // Issuing a restricted asset must cointain at least 4 CTxOut(Avian Burn Tx, Asset Creation, Root Owner Token Transfer, and CNullAssetTxVerifierString)
+    // Issuing a restricted asset must contain at least 4 CTxOut(Avian Burn Tx, Asset Creation, Root Owner Token Transfer, and CNullAssetTxVerifierString)
     if (tx.vout.size() < 4) {
         strError = "bad-txns-issue-restricted-vout-size-to-small";
         return false;
@@ -2490,7 +2490,7 @@ bool CAssetsCache::DumpCacheToDatabase()
                 }
             }
 
-            // Undo the transfering by updating the balances in the database
+            // Undo the transferring by updating the balances in the database
 
             for (auto undoTransfer : setNewTransferAssetsToRemove) {
                 auto pair = std::make_pair(undoTransfer.transfer.strName, undoTransfer.address);
@@ -2673,12 +2673,12 @@ bool CAssetsCache::DumpCacheToDatabase()
             if (undoVerifiers.fUndoingRessiue) {
                 if (!prestricteddb->WriteVerifier(assetName, undoVerifiers.verifier)) {
                     dirty = true;
-                    message = "_Failed Writing undo restricted verifer to database";
+                    message = "_Failed Writing undo restricted verifier to database";
                 }
             } else {
                 if (!prestricteddb->EraseVerifier(assetName)) {
                     dirty = true;
-                    message = "_Failed Writing undo restricted verifer to database";
+                    message = "_Failed Writing undo restricted verifier to database";
                 }
             }
 
@@ -4450,7 +4450,7 @@ bool CheckVerifierString(const std::string& verifier, std::set<std::string>& set
 
         std::string edited_qualifier;
 
-        // Qualifer string was stripped above, so we need to add back the #
+        // Qualifier string was stripped above, so we need to add back the #
         edited_qualifier = QUALIFIER_CHAR + qualifier;
 
         if (!IsQualifierNameValid(edited_qualifier)) {
@@ -5021,7 +5021,7 @@ bool CheckReissueAsset(const CReissueAsset& asset, std::string& strError)
     }
 
     /// -------- TESTNET ONLY ---------- ///
-    // Testnet has a couple blocks that have invalid nReissue values before constriants were created
+    // Testnet has a couple blocks that have invalid nReissue values before constraints were created
     bool fSkip = false;
     if (Params().GetChainType() == ChainType::TESTNET) {
         if (asset.strName == "GAMINGWEB" && asset.nReissuable == 109) {

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -71,7 +71,7 @@ struct CBlockAssetUndo;
 #define MAX_CACHE_ASSETS_SIZE 2500
 
 // Create map that store that state of current reissued transaction that the mempool as accepted.
-// If an asset name is in this map, any other reissue transactions wont be accepted into the mempool
+// If an asset name is in this map, any other reissue transactions won't be accepted into the mempool
 extern std::map<uint256, std::string> mapReissuedTx;
 extern std::map<std::string, uint256> mapReissuedAssets;
 
@@ -342,7 +342,7 @@ public :
     //! Write asset cache data to database
     bool DumpCacheToDatabase();
 
-    //! Clear all dirty cache sets, vetors, and maps
+    //! Clear all dirty cache sets, vectors, and maps
     void ClearDirtyCache() {
 
         vUndoAssetAmount.clear();

--- a/src/assets/cbor.h
+++ b/src/assets/cbor.h
@@ -164,11 +164,11 @@ inline bool DecodeProfile(const std::string& payload, ANSProfileData& out, std::
         if (pos >= len) { error = "truncated at key"; return false; }
         uint8_t kh   = d[pos++];
         uint8_t kmaj = kh >> 5;
-        uint8_t kinf = kh & 0x1fu;
+        uint8_t kind = kh & 0x1fu;
         if (kmaj != 0)   { error = "non-integer map key"; return false; }
-        if (kinf == 31)  { error = "indefinite-length key not allowed"; return false; }
+        if (kind == 31)  { error = "indefinite-length key not allowed"; return false; }
         uint64_t key;
-        if (!read_arg(kinf, key)) return false;
+        if (!read_arg(kind, key)) return false;
 
         // Value: tstr (major 3) or bstr (major 2).
         if (pos >= len) { error = "truncated at value"; return false; }

--- a/src/assets/rewards.cpp
+++ b/src/assets/rewards.cpp
@@ -156,7 +156,7 @@ bool GenerateDistributionList(const CRewardSnapshot& p_rewardSnapshot, std::vect
     for (auto & ownership : nonExceptionOwnerships) {
         // Get percentage of total ownership
         long double percent = (long double)ownership.amount / (long double)totalAmtOwned;
-        // Caculate the reward with potentional unit inaccurancies e.g with units 4, 90054100 satoshis = 0.90054100
+        // Calculate the reward with potentional unit inaccurancies e.g with units 4, 90054100 satoshis = 0.90054100
         CAmount rewardAmt = percent * modifiedPaymentInAssetUnits * static_cast<CAmount>(pow(10, COIN_DIGITS_PAST_DECIMAL - distributionAsset.units));
         // Remove all none accurate units e.g with units 4 90054100 => 9005
         rewardAmt /= static_cast<CAmount>(pow(10, COIN_DIGITS_PAST_DECIMAL - distributionAsset.units));

--- a/src/qt/forms/createassetdialog.ui
+++ b/src/qt/forms/createassetdialog.ui
@@ -672,7 +672,7 @@
           <item>
            <widget class="QPushButton" name="availabilityButton">
             <property name="text">
-             <string>Check Availabilty</string>
+             <string>Check Availability</string>
             </property>
            </widget>
           </item>
@@ -767,7 +767,7 @@
                <number>80</number>
               </property>
               <property name="toolTip">
-               <string>How divisble the assets will be (e.g. 8 = 1.00000000, 2 = 1.00)</string>
+               <string>How divisible the assets will be (e.g. 8 = 1.00000000, 2 = 1.00)</string>
               </property>
               <property name="maximum">
                <number>8</number>

--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -1297,7 +1297,7 @@ QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:checked {
   background-position: center;
 }
 
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::separator {
 }
 
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -1300,7 +1300,7 @@ QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:checked {
   background-position: center;
 }
 
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::seperator {
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::separator {
 }
 
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -8,7 +8,7 @@ import string
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import (
-    BITCOIN_PID_FILENAME_DEFAULT,
+    AVIAN_PID_FILENAME_DEFAULT,
     ErrorMatch,
 )
 
@@ -40,7 +40,7 @@ class FilelockTest(BitcoinTestFramework):
         self.log.info("Check that cookie and PID file are not deleted when attempting to start a second bitcoind using the same datadir/blocksdir")
         cookie_file = datadir / ".cookie"
         assert cookie_file.exists()  # should not be deleted during the second bitcoind instance shutdown
-        pid_file = datadir / BITCOIN_PID_FILENAME_DEFAULT
+        pid_file = datadir / AVIAN_PID_FILENAME_DEFAULT
         assert pid_file.exists()
 
         if self.is_wallet_compiled():

--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -13,7 +13,7 @@ import subprocess
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import (
-    BITCOIN_PID_FILENAME_DEFAULT,
+    AVIAN_PID_FILENAME_DEFAULT,
     ErrorMatch,
 )
 from test_framework.util import assert_equal
@@ -228,7 +228,7 @@ class InitTest(BitcoinTestFramework):
         self.log.info(f"-> path relative to datadir ({custom_pidfile_relative})")
         self.restart_node(0, [f"-pid={custom_pidfile_relative}"])
         datadir = self.nodes[0].chain_path
-        assert not (datadir / BITCOIN_PID_FILENAME_DEFAULT).exists()
+        assert not (datadir / AVIAN_PID_FILENAME_DEFAULT).exists()
         assert (datadir / custom_pidfile_relative).exists()
         self.stop_node(0)
         assert not (datadir / custom_pidfile_relative).exists()
@@ -236,7 +236,7 @@ class InitTest(BitcoinTestFramework):
         custom_pidfile_absolute = Path(self.options.tmpdir) / BITCOIN_PID_FILENAME_CUSTOM
         self.log.info(f"-> absolute path ({custom_pidfile_absolute})")
         self.restart_node(0, [f"-pid={custom_pidfile_absolute}"])
-        assert not (datadir / BITCOIN_PID_FILENAME_DEFAULT).exists()
+        assert not (datadir / AVIAN_PID_FILENAME_DEFAULT).exists()
         assert custom_pidfile_absolute.exists()
         self.stop_node(0)
         assert not custom_pidfile_absolute.exists()

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -23,6 +23,7 @@ requestor
 ser
 siz
 stap
+tradin
 unparseable
 unser
 useable


### PR DESCRIPTION
Consolidates the CI improvements into one PR (originally just the Build/Unit-tests split). Depends on #256 (lint suite passing on main), now merged.

## Changes
1. **Split Build and Unit tests into separate workflow steps.** `03_test_script.sh` gains a `CI_PHASE` selector (build|test|all, default all); the workflow runs `Build` (`CI_PHASE=build`) then `Unit tests` (`CI_PHASE=test`), each with its own log and status. No artifact passing: both steps share the runner and the build tree persists via the host-mounted `BASE_BUILD_DIR`.
2. **Add a `Lint` job** that builds `ci/lint_imagefile` and runs the `test/lint/test_runner`, enforcing the lint suite on every push and PR (runs in parallel with the build job).
3. **Dedupe push/PR runs.** The concurrency group now keys on `workflow + ref`, so the `push` and `pull_request` events for the same branch share a group and the duplicate is auto-cancelled (previously they landed in separate groups and both ran).

Verified on `feat/rip-25-keygen` (the split) and locally (the lint suite). The Unit-tests step re-runs `base_install` (~1-2 min) since it is a fresh container; that is the tradeoff for separate steps without artifact passing.