### PR TITLE
lint: remove dead lint_subtree function

### DIFF
--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -227,24 +227,6 @@ fn get_pathspecs_default_excludes() -> Vec<String> {
         .collect()
 }
 
-fn lint_subtree() -> LintResult {
-    // This only checks that the trees are pure subtrees, it is not doing a full
-    // check with -r to not have to fetch all the remotes.
-    let mut good = true;
-    for subtree in get_subtrees() {
-        good &= Command::new("test/lint/git-subtree-check.sh")
-            .arg(subtree)
-            .status()
-            .expect("command_error")
-            .success();
-    }
-    if good {
-        Ok(())
-    } else {
-        Err("".to_string())
-    }
-}
-
 fn lint_scripted_diff() -> LintResult {
     if Command::new("test/lint/commit-script-check.sh")
         .arg(commit_range())


### PR DESCRIPTION
Removes the unused `lint_subtree()` function from the lint test_runner.

When the lint suite was localized to Avian, the subtree linter was dropped from the run list (Avian's vendored trees like `src/algo` aren't managed as git subtrees), but the function itself was left defined and unreferenced. It emitted a `dead_code` warning on every lint run:

```
warning: function `lint_subtree` is never used
   --> src/main.rs:230:4
```

`get_subtrees()` is kept — other linters (markdown ignore paths, etc.) still use it.

No functional change; the lint suite already passes. This just removes the warning noise.