### PR TITLE
RIP-25: ML-DSA-44 post-quantum signatures (witness v2) — Phase 0 consensus hardening

### DIFF
--- a/ci/test/00_setup_env_native.sh
+++ b/ci/test/00_setup_env_native.sh
@@ -14,12 +14,14 @@ export RUN_UNIT_TESTS=true
 # The functional (Python) test suite is not yet localized to Avian; keep it off for now.
 export RUN_FUNCTIONAL_TESTS=false
 export GOAL="install"
+# RIP-25 (feat/rip-25-keygen): build liboqs from source and build WITH_LIBOQS=ON so the
+# ML-DSA-44 code and its tests (pqkey_tests, mldsa44_sighash_tests) are actually exercised.
+# 03_test_script.sh builds liboqs when BUILD_LIBOQS=true; the version is pinned to match
+# depends/packages/liboqs.mk. WITH_LIBOQS defaults ON and is a hard error if liboqs is
+# missing, so the install must precede cmake.
+export BUILD_LIBOQS=true
+export LIBOQS_VERSION=0.16.0
 # BUILD_TESTS defaults OFF, so it must be enabled explicitly or test_avian is never built
 # and ctest finds no tests to run. BUILD_GUI_TESTS is forced OFF: the Qt GUI test suite
-# (test_avian-qt: URI/RPC-console/wallet tests) is not yet localized to Avian (it still
-# assumes Bitcoin's URI scheme etc.), same status as the functional tests. The GUI itself
-# is still built (BUILD_GUI=ON) so the artifact is produced. WITH_LIBOQS defaults ON, but
-# liboqs (ML-DSA-44 / RIP-25) is not part of the CI build yet; pin it OFF so the build is
-# deterministic and quiet (avoids the not-found warning and auto-downgrade) until the
-# keygen branch lands and a liboqs job is added.
-export AVIAN_CONFIG="-DBUILD_GUI=ON -DBUILD_GUI_TESTS=OFF -DWITH_ZMQ=ON -DENABLE_IPC=OFF -DWERROR=ON -DBUILD_TESTS=ON -DWITH_LIBOQS=OFF"
+# (test_avian-qt) is not yet localized to Avian; the GUI itself is still built (BUILD_GUI=ON).
+export AVIAN_CONFIG="-DBUILD_GUI=ON -DBUILD_GUI_TESTS=OFF -DWITH_ZMQ=ON -DENABLE_IPC=OFF -DWERROR=ON -DBUILD_TESTS=ON -DWITH_LIBOQS=ON"

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -33,8 +33,14 @@ export FUZZ_EMPTY_MIN_TIME=${FUZZ_EMPTY_MIN_TIME:-2}
 export FUZZ_EXCLUDE_TARGETS=${FUZZ_EXCLUDE_TARGETS:-utxo_snapshot,utxo_snapshot_invalid,p2p_headers_presync,utxo_total_supply,integer}
 export GOAL="all"
 export CI_CONTAINER_CAP="--cap-add SYS_PTRACE"  # If run with (ASan + LSan), the container needs access to ptrace (https://github.com/google/sanitizers/issues/764)
+# WITH_LIBOQS=OFF: the fuzz job does not install liboqs and does not fuzz the real
+# ML-DSA-44 verifier (it uses the stub). WITH_LIBOQS defaults ON and is a hard
+# FATAL_ERROR when liboqs is missing, so it must be set OFF explicitly here or the
+# fuzz build's cmake configure aborts. (Fuzzing the real ML-DSA path is a follow-up
+# that would also need a BUILD_LIBOQS step in this job.)
 export AVIAN_CONFIG="\
  -DBUILD_FOR_FUZZING=ON \
+ -DWITH_LIBOQS=OFF \
  -DSANITIZERS=fuzzer,address,undefined,float-divide-by-zero,integer \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -123,6 +123,28 @@ fi
 # container runs via the host-mounted BASE_BUILD_DIR.
 if [ "${CI_PHASE}" != "test" ]; then
 
+# RIP-25: build and install liboqs (ML-DSA-44) so a WITH_LIBOQS=ON build can find and link
+# it. The native CI uses system packages (NO_DEPENDS), so liboqs is not otherwise present,
+# and cmake/liboqs.cmake is a hard error when WITH_LIBOQS=ON and liboqs is missing. Pinned
+# and configured to match depends/packages/liboqs.mk (minimal SIG_ml_dsa_44 static build).
+# Only needed in the build phase; the static lib is baked into the binaries for the test phase.
+if [ "${BUILD_LIBOQS}" = "true" ]; then
+  LIBOQS_VERSION="${LIBOQS_VERSION:-0.16.0}"
+  LIBOQS_SHA256="162d5b510518ee5f285f82fa1f16402a885176e818bf1b1a4c3c91c9a2f01eae"
+  (
+    set -e
+    cd "${BASE_SCRATCH_DIR}"
+    ${CI_RETRY_EXE} curl --location --fail "https://github.com/open-quantum-safe/liboqs/archive/refs/tags/${LIBOQS_VERSION}.tar.gz" -o liboqs.tar.gz
+    echo "${LIBOQS_SHA256}  liboqs.tar.gz" | sha256sum -c -
+    tar xzf liboqs.tar.gz
+    cmake -S "liboqs-${LIBOQS_VERSION}" -B liboqs-build -GNinja \
+      -DOQS_BUILD_ONLY_LIB=ON -DOQS_MINIMAL_BUILD=SIG_ml_dsa_44 \
+      -DOQS_USE_OPENSSL=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr/local
+    cmake --build liboqs-build
+    cmake --install liboqs-build
+  )
+fi
+
 AVIAN_CONFIG_ALL="-DBUILD_BENCH=OFF -DBUILD_FUZZ_BINARY=OFF"
 if [ -z "$NO_DEPENDS" ]; then
   AVIAN_CONFIG_ALL="${AVIAN_CONFIG_ALL} -DCMAKE_TOOLCHAIN_FILE=$DEPENDS_DIR/$HOST/toolchain.cmake"

--- a/cmake/liboqs.cmake
+++ b/cmake/liboqs.cmake
@@ -50,10 +50,30 @@ if(WITH_LIBOQS)
     target_compile_definitions(core_interface INTERFACE HAVE_LIBOQS)
     message(STATUS "liboqs found — ML-DSA-44 (RIP-25) post-quantum signatures enabled.")
   else()
-    message(WARNING
-      "liboqs not found. ML-DSA-44 (RIP-25) post-quantum signatures will be disabled.\n"
-      "Install liboqs (https://github.com/open-quantum-safe/liboqs) or set WITH_LIBOQS=OFF to silence this warning."
+    # Hard error, never a silent downgrade. ML-DSA-44 (RIP-25) verification is a
+    # consensus rule once the deployment activates: a node built without liboqs
+    # would evaluate every post-quantum output with the stub verifier (which
+    # returns false) and could fork from liboqs-enabled nodes. Disabling
+    # post-quantum support must therefore be a deliberate, explicit choice, not
+    # an accident of a missing dependency.
+    message(FATAL_ERROR
+      "liboqs not found, but WITH_LIBOQS is ON (the default).\n"
+      "ML-DSA-44 (RIP-25) post-quantum signature verification is a consensus rule once the "
+      "deployment activates, so a missing liboqs is a hard error rather than a silent downgrade.\n"
+      "Fix one of:\n"
+      "  - install liboqs (https://github.com/open-quantum-safe/liboqs), or build via the depends "
+      "system which provides it; or\n"
+      "  - pass -DWITH_LIBOQS=OFF to opt out explicitly, ONLY for a build that will never act as a "
+      "validating or mining node once RIP-25 has activated on its network."
     )
-    set(WITH_LIBOQS OFF)
   endif()
+else()
+  # Explicit opt-out. Allowed, but loudly flagged: such a binary cannot verify
+  # post-quantum outputs and is unsafe as a consensus node after activation.
+  message(WARNING
+    "WITH_LIBOQS=OFF: building WITHOUT ML-DSA-44 (RIP-25) post-quantum support.\n"
+    "This binary MUST NOT be used as a validating or mining node once the RIP-25 deployment "
+    "activates on the target network: it cannot verify post-quantum outputs and may fork from "
+    "liboqs-enabled nodes."
+  )
 endif()

--- a/depends/packages/liboqs.mk
+++ b/depends/packages/liboqs.mk
@@ -7,10 +7,10 @@
 # Ported from Ravencoin RIP-25 <https://github.com/RavenProject/Ravencoin/pull/1281>
 
 package=liboqs
-$(package)_version=0.12.0
+$(package)_version=0.16.0
 $(package)_download_path=https://github.com/open-quantum-safe/liboqs/archive/refs/tags/
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=df999915204eb1eba311d89e83d1edd3a514d5a07374745d6a9e5b2dd0d59c08
+$(package)_sha256_hash=162d5b510518ee5f285f82fa1f16402a885176e818bf1b1a4c3c91c9a2f01eae
 $(package)_dependencies=
 
 define $(package)_set_vars

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -1,0 +1,234 @@
+# RIP-25: ML-DSA-44 Post-Quantum Transaction Outputs
+
+- **Status:** Draft (working document, not frozen)
+- **Network:** Avian
+- **Witness version:** 2
+- **Signature scheme:** ML-DSA-44 (NIST FIPS 204)
+- **Deployment:** BIP9 `mldsa44` (bit 11), `NEVER_ACTIVE` on mainnet
+- **Scope of this version:** AVN outputs only. Assets and hybrid (ECDSA+ML-DSA) are out of scope and specified separately in later revisions.
+
+> This document records the consensus rules of the ML-DSA-44 output type as they exist in
+> Avian Core v5.0 and marks the decisions that must be resolved before the specification is
+> frozen. Sections tagged **OPEN** describe current behavior that is expected to change; do not
+> treat them as final. Once frozen, any consensus-affecting change requires updating this
+> document and its test vectors together.
+
+## Abstract
+
+RIP-25 defines a SegWit witness version 2 output type whose spending authority is an ML-DSA-44
+(lattice-based, FIPS 204) signature rather than an ECDSA signature. The output commits to a
+32-byte hash of an ML-DSA-44 public key. A spend reveals the public key and a signature over the
+transaction digest. Existing ECDSA outputs are unaffected.
+
+## Motivation
+
+ECDSA is vulnerable to a sufficiently large quantum computer. ML-DSA-44 is a NIST-standardized
+signature scheme believed resistant to such attacks. RIP-25 gives Avian holders an optional,
+quantum-resistant ownership type that coexists with legacy addresses, activated only by community
+signalling and only for outputs created after activation. It does not migrate or threaten existing
+funds.
+
+## Constants
+
+| Name | Value | Source |
+|---|---|---|
+| Public key length | 1312 bytes | `mldsa::PUBKEY_SIZE`, `CPQPubKey::SIZE` (`src/crypto/mldsa.h`) |
+| Signature length | 2420 bytes | `mldsa::SIG_SIZE` (`src/crypto/mldsa.h`) |
+| Seed length | 32 bytes | `mldsa::SEED_SIZE` |
+| Secret key length | 2560 bytes | `mldsa::SECRETKEY_SIZE` |
+| Witness program length | 32 bytes | `SHA256` output |
+| Witness version | 2 | `OP_2` |
+| Sighash type | `0x41` (`SIGHASH_ALL | SIGHASH_FORKID`) | `interpreter.cpp:1747` |
+
+## Specification
+
+### Output format
+
+```
+scriptPubKey = OP_2 <32-byte program>          (34 bytes total: 0x52 0x20 <program>)
+program      = SHA256(public_key)              (single SHA256, not Hash160, not SHA256d)
+```
+
+`SHA256` is the plain 32-byte SHA-256 of the 1312-byte public key (`src/pqkey.cpp:19-25`).
+
+### Address encoding
+
+Witness version 2, encoded with bech32m per BIP350 (`src/key_io.cpp:69-76`, decode `:198-203`),
+using the same human-readable part as all other Avian bech32 addresses (no distinct HRP for PQ).
+Decoding accepts a v2 program only when its length is exactly 32 bytes.
+
+### Witness structure
+
+The witness stack for a RIP-25 input MUST contain exactly two elements, in this order
+(`interpreter.cpp:2037-2041`):
+
+```
+witness = [ signature (2420 bytes),   // stack[0]
+            public_key (1312 bytes) ] // stack[1]
+```
+
+Any other stack size fails with `SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH`.
+
+### Message construction (signature hash)
+
+The message signed by ML-DSA-44 is a BIP143-style transaction digest (`interpreter.cpp:1742-1749`,
+signing side `src/script/sign.cpp:98-121`):
+
+```
+scriptCode = OP_2 <program>                    (34 bytes)
+sighash    = SignatureHash(scriptCode, tx, nIn, 0x41, amount, SigVersion::WITNESS_V0, txdata)
+```
+
+- The sighash type is hardcoded to `SIGHASH_ALL | SIGHASH_FORKID` (`0x41`). No other sighash modes
+  are supported, and no sighash byte is carried in the witness. See **OPEN: sighash policy**.
+- `amount` is the value of the output being spent (BIP143).
+- Using the 34-byte `OP_2 <program>` scriptCode distinguishes a RIP-25 preimage from a witness v0
+  (P2WPKH/P2WSH) preimage, because a v0 scriptCode can never take that shape.
+- The 32-byte `sighash` is passed to ML-DSA-44 as a plain message (the caller pre-hashes; ML-DSA's
+  own HashML-DSA mode is not used). See **OPEN: domain separation**.
+
+### Verification algorithm
+
+When `SCRIPT_VERIFY_PQ_HYBRID` is set (deployment active), a witness v2 / 32-byte-program input is
+verified as follows (`interpreter.cpp:2027-2068`), failing on the first violated rule:
+
+1. `stack.size() == 2`, else `SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH`.
+2. `public_key.size() == 1312`, else `SCRIPT_ERR_PQ_PUBKEY_SIZE`.
+3. `signature.size() == 2420`, else `SCRIPT_ERR_PQ_SIGNATURE_SIZE`.
+4. `SHA256(public_key) == program` (32-byte compare), else `SCRIPT_ERR_PQ_WITNESS_PROGRAM_MISMATCH`.
+5. `ML-DSA-44.Verify(public_key, signature, sighash)` succeeds, else `SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED`.
+
+On success the input is valid; no further script evaluation occurs (RIP-25 inputs never enter
+`EvalScript`).
+
+Error codes are defined at `src/script/script_error.h:90-94`.
+
+### P2SH exclusion
+
+A RIP-25 program wrapped in P2SH is not recognized (`!is_p2sh` guard, `interpreter.cpp:2027`).
+RIP-25 outputs are native SegWit only.
+
+### Pre-activation semantics
+
+Before `SCRIPT_VERIFY_PQ_HYBRID` is set, a witness v2 / 32-byte-program output is treated as an
+unknown future upgrade and is **anyone-can-spend** at the consensus layer (`interpreter.cpp:2031-2036`
+returns `true`), unless `SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM` is set (relay policy),
+in which case it returns `SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM`.
+
+Consequence: **RIP-25 outputs created before activation are not secure and must not be used to
+hold value on mainnet.** The wallet enforces this by refusing to generate `pq` addresses until the
+deployment is active (`src/wallet/rpc/addresses.cpp:69-75`).
+
+### Key derivation (OPEN)
+
+Wallets derive ML-DSA-44 keys through a descriptor:
+
+```
+mldsa44(<xpub>/25h/921h/0h/<0h|1h>/*h)         (purpose 25 = RIP-25, coin type 921 = Avian)
+```
+
+All steps are hardened; the final step must be `/*h` (`src/script/descriptor.cpp:2678-2717`,
+`src/wallet/walletutil.cpp:63-75`). The 32-byte hardened BIP32 child private key at the leaf is
+used as the ML-DSA-44 seed.
+
+> **OPEN (must resolve before freeze).** The current seed-to-keypair step is not a
+> FIPS-204-standard derandomized keygen. Because liboqs 0.12.0 does not export a public
+> derandomized keypair function, `src/crypto/mldsa.cpp:36-82` temporarily replaces liboqs's global
+> RNG with a SHA256 counter-mode KDF to force determinism. This couples every address to liboqs's
+> internal RNG call pattern and has no known-answer coverage. Before freeze this MUST be replaced
+> with a written, standards-aligned derandomized keygen (upgrade liboqs to expose
+> `OQS_SIG_ml_dsa_44_keypair_derand`, or vendor a minimal FIPS-204 keygen) and pinned with the
+> test vectors below. The exact byte-level derivation becomes normative here.
+
+## Activation
+
+RIP-25 activates via BIP9 versionbits, deployment `mldsa44`, bit 11
+(`src/consensus/params.h:40`, `src/deploymentinfo.cpp:21-24`).
+
+| Network | State | Threshold / period |
+|---|---|---|
+| mainnet | `NEVER_ACTIVE` | 36288 / 40320 (90%, ~2 weeks at 30s blocks) when set |
+| testnet, testnet4 | `ALWAYS_ACTIVE` | 1512 / 2016 |
+| regtest | `ALWAYS_ACTIVE` | 108 / 144 |
+
+When the deployment is active at a block, `GetBlockScriptFlags` adds
+`SCRIPT_VERIFY_PQ_HYBRID = 1U << 22` (`src/validation.cpp:2667-2670`, `interpreter.h:151-152`).
+
+> Note on naming: the flag is called `SCRIPT_VERIFY_PQ_HYBRID`, but the implemented rule is pure
+> ML-DSA-44 with no ECDSA component. A true hybrid scheme is a separate future output type.
+
+**Mempool vs consensus asymmetry:** `SCRIPT_VERIFY_PQ_HYBRID` is in `STANDARD_SCRIPT_VERIFY_FLAGS`
+but not `MANDATORY_SCRIPT_VERIFY_FLAGS` (`src/policy/policy.h`). The mempool therefore enforces
+RIP-25 verification on all networks regardless of activation, while consensus enforces it only once
+the deployment is active. This is documented so implementers do not rely on mempool acceptance as
+evidence of consensus validity before activation.
+
+## Resource limits and DoS (OPEN)
+
+> **OPEN (must resolve before freeze).** No PQ-specific cost accounting exists today. A witness v2
+> input contributes 0 sigops (`interpreter.cpp:2205-2219`), and `IsWitnessStandard`
+> (`src/policy/policy.cpp:264-330`) has no witness-v2 branch, so the 2420/1312-byte elements bypass
+> the standard 80-byte stack-item limit. An ML-DSA-44 verification is CPU-heavy yet currently free
+> against every limit. Before freeze the specification MUST define at least: maximum PQ
+> verifications per transaction and per block, maximum PQ witness element and total witness size,
+> mempool admission caps, and a minimum relay fee floor sized so a ~3.7 KB spend plus its
+> verification cannot be purchased too cheaply.
+
+## Domain separation (OPEN)
+
+> **OPEN (must resolve before freeze).** Separation currently rests only on the 34-byte scriptCode
+> shape and the `SIGHASH_FORKID` bit. The ML-DSA-44 verify call uses the context-free API with an
+> empty context string (`src/crypto/mldsa.cpp:113-116`). Before freeze the specification SHOULD
+> adopt an explicit domain separator (a non-empty ML-DSA context string such as
+> `"AVN-RIP25-mldsa44"` combined with a network tag, or a tagged prehash) so a signature cannot be
+> replayed across networks (mainnet vs testnet) or, in a future asset-enabled revision, between AVN
+> and asset spends.
+
+## Open decisions (consolidated, must resolve before freeze)
+
+1. **Key derivation:** replace the liboqs-RNG-hijack with a written derandomized keygen and pin it
+   with vectors (see Key derivation).
+2. **Domain separation:** add an explicit context/network separator (see Domain separation).
+3. **Resource limits:** define per-transaction and per-block PQ verification and size limits (see
+   Resource limits).
+4. **Sighash policy:** confirm `SIGHASH_ALL | SIGHASH_FORKID` only is the permanent rule.
+5. **liboqs requirement:** an activated node built without liboqs currently fails every PQ
+   signature (`src/crypto/mldsa.cpp:120-137` stub returns `false`), and the build silently
+   downgrades `WITH_LIBOQS=OFF` on a warning (`cmake/liboqs.cmake`). Before freeze, liboqs MUST be
+   a hard build requirement for any release capable of activation, and its exact revision pinned.
+
+## Test vectors
+
+To be committed at `src/test/data/rip25_vectors.json` and treated as normative. Each vector:
+
+```
+seed -> public_key -> witness_program -> address ->
+unsigned_tx -> sighash -> signature -> final_tx -> txid / wtxid -> expected_verify_result
+```
+
+Vectors MUST be reproduced byte-for-byte across Linux, Windows and macOS on x86_64 and ARM64, and
+across a clean liboqs rebuild. They pin the derivation and the digest so neither can drift silently.
+
+## Reference implementation
+
+- Consensus verify: `src/script/interpreter.cpp:2027-2068`
+- Signature hash: `src/script/interpreter.cpp:1742-1749`
+- Signing: `src/script/sign.cpp:98-121`
+- Crypto wrapper / keygen: `src/crypto/mldsa.{h,cpp}`, keys `src/pqkey.{h,cpp}`
+- Address type: `src/addresstype.h:132-144`, `src/script/solver.{h,cpp}`
+- Descriptor: `src/script/descriptor.cpp:2161-2362`
+- Activation: `src/consensus/params.h:40`, `src/kernel/chainparams.cpp`, `src/validation.cpp:2667-2670`
+- Error codes: `src/script/script_error.h:90-94`
+
+## Backwards compatibility
+
+RIP-25 is a soft fork. Non-upgraded nodes see RIP-25 outputs as anyone-can-spend and continue to
+follow the chain; they must upgrade (with liboqs) before activation to enforce the new rule and
+avoid diverging. Existing ECDSA outputs remain valid and spendable unchanged. Adoption is voluntary.
+
+## References
+
+- NIST FIPS 204 (ML-DSA)
+- BIP141 (SegWit), BIP143 (v0 signature digest), BIP350 (bech32m)
+- Ravencoin RIP-25 origin: https://github.com/RavenProject/Ravencoin/pull/1281
+- Avian v5.0.0 release notes: `doc/release-notes/release-notes-5.0.0.md`

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -90,8 +90,9 @@ sighash    = SignatureHash(scriptCode, tx, nIn, 0x41, amount, SigVersion::WITNES
 - `amount` is the value of the output being spent (BIP143).
 - Using the 34-byte `OP_2 <program>` scriptCode distinguishes a RIP-25 preimage from a witness v0
   (P2WPKH/P2WSH) preimage, because a v0 scriptCode can never take that shape.
-- The 32-byte `sighash` is passed to ML-DSA-44 as a plain message (the caller pre-hashes; ML-DSA's
-  own HashML-DSA mode is not used). See **OPEN: domain separation**.
+- The 32-byte `sighash` is passed to ML-DSA-44 as the message in "pure" mode (the caller pre-hashes;
+  ML-DSA's own HashML-DSA mode is not used), together with a non-empty FIPS-204 context string for
+  domain separation. See **Domain separation**.
 
 ### Verification algorithm
 
@@ -203,22 +204,42 @@ evidence of consensus validity before activation.
 > mempool admission caps, and a minimum relay fee floor sized so a ~3.7 KB spend plus its
 > verification cannot be purchased too cheaply.
 
-## Domain separation (OPEN)
+## Domain separation
 
-> **OPEN (must resolve before freeze).** Separation currently rests only on the 34-byte scriptCode
-> shape and the `SIGHASH_FORKID` bit. The ML-DSA-44 verify call uses the context-free API with an
-> empty context string (`src/crypto/mldsa.cpp:113-116`). Before freeze the specification SHOULD
-> adopt an explicit domain separator (a non-empty ML-DSA context string such as
-> `"AVN-RIP25-mldsa44"` combined with a network tag, or a tagged prehash) so a signature cannot be
-> replayed across networks (mainnet vs testnet) or, in a future asset-enabled revision, between AVN
-> and asset spends.
+Every ML-DSA-44 signature is bound to an explicit domain-separation **context** through FIPS 204's
+native context string (the `pre = 0x00 || len(ctx) || ctx` prefix prepended to the message before
+signing and verification). The context is:
+
+```
+ctx = "AVN/RIP-25/ML-DSA-44/v1/" || genesis_block_hash        (24 + 32 = 56 bytes)
+```
+
+The genesis block hash is the canonical, immutable per-network identifier, so a signature made for
+one network (e.g. testnet) can never verify on another (mainnet), independently of the transaction
+contents. The versioned prefix separates RIP-25 from any other ML-DSA use and lets a future context
+change be unambiguous (`.../v2`), and reserves room for a distinct context in a future asset-enabled
+revision (AVN vs asset spends).
+
+The context is a single process value, set once from the active network in `SelectParams()` and read
+by both the consensus verifier and the signer via `GetMLDsa44DomainContext()`
+(`src/script/interpreter.h`). It lives in the `bitcoin_consensus` layer because the script verifier
+cannot depend on chainparams; the network-selection layer pushes the value in. Signing and verifying
+therefore always agree, and there is no per-call-site value that could drift between mempool and
+consensus. Enforced by `mldsa44_sighash_tests.cpp` (`domain_separation_binds_the_network`).
+
+> Note: this is defence in depth. BIP143 already binds each input to its prevout, so a spend built on
+> one chain does not have a valid preimage on another; the context makes the network binding explicit
+> and independent of that, and generalises to non-network contexts.
 
 ## Open decisions (consolidated, must resolve before freeze)
 
 1. **Key derivation:** RESOLVED. The liboqs-RNG-hijack is replaced by an explicit, versioned,
    standards-aligned derandomized keygen (`xi = SHA256(DST || leaf)`, then FIPS-204
    `KeyGen_internal(xi)`), pinned by a known-answer vector (see Key derivation).
-2. **Domain separation:** add an explicit context/network separator (see Domain separation).
+2. **Domain separation:** RESOLVED. Every signature is bound to a FIPS-204 context string
+   `"AVN/RIP-25/ML-DSA-44/v1/" || genesis_block_hash`, set once from the active network in
+   `SelectParams()` and shared by signer and verifier, giving explicit per-network binding (see
+   Domain separation).
 3. **Resource limits:** define per-transaction and per-block PQ verification and size limits (see
    Resource limits).
 4. **Sighash policy:** RESOLVED. `SIGHASH_ALL | SIGHASH_FORKID` is the permanent and only rule; no

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -271,13 +271,17 @@ consensus. Enforced by `mldsa44_sighash_tests.cpp` (`domain_separation_binds_the
    sighash-type byte is carried in the witness. The two magic `0x41` literals are replaced by the
    named `SIGHASH_ALL | SIGHASH_FORKID` on both the signing and verifying sides, and the rule is
    locked behaviorally by `mldsa44_sighash_tests.cpp` (see Signature message).
-5. **liboqs requirement:** PARTIALLY RESOLVED. The build no longer silently downgrades: with
-   `WITH_LIBOQS` ON (the default) a missing liboqs is now a `FATAL_ERROR`, and disabling
-   post-quantum support requires an explicit `-DWITH_LIBOQS=OFF` (`cmake/liboqs.cmake`). The stub
-   verifier still returns `false` when built that way (`src/crypto/mldsa.cpp`), so such a binary
-   must not act as a validating node after activation. Remaining before freeze: pin liboqs to an
-   exact revision (currently the 0.12.0 tag plus sha256 in `depends/packages/liboqs.mk`) and assert
-   the release build cannot reach the stub path.
+5. **liboqs requirement:** RESOLVED. Three defences make a stub-only node impossible to run into a
+   consensus split:
+   - **Build:** with `WITH_LIBOQS` ON (the default) a missing liboqs is a `FATAL_ERROR`; disabling
+     post-quantum support requires an explicit `-DWITH_LIBOQS=OFF` (`cmake/liboqs.cmake`).
+   - **Pin:** liboqs is pinned by exact version plus tarball SHA-256 in `depends/packages/liboqs.mk`
+     (`0.12.0`, `df9999...9c08`), verified against the downloaded artifact, so the depends build is
+     reproducible and rejects any tampered source.
+   - **Runtime:** `AppInitSanityChecks` refuses to start (via `mldsa::IsAvailable()`) when the build
+     lacks liboqs and the selected network's `DEPLOYMENT_MLDSA44` is not `NEVER_ACTIVE`. A stub
+     binary can therefore only run where the deployment can never activate; the moment mainnet is
+     given a real `nStartTime`, stub builds are refused there too.
 
 ## Test vectors
 

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -96,7 +96,7 @@ sighash    = SignatureHash(scriptCode, tx, nIn, 0x41, amount, SigVersion::WITNES
 
 ### Verification algorithm
 
-When `SCRIPT_VERIFY_PQ_HYBRID` is set (deployment active), a witness v2 / 32-byte-program input is
+When `SCRIPT_VERIFY_MLDSA44` is set (deployment active), a witness v2 / 32-byte-program input is
 verified as follows (`interpreter.cpp:2027-2068`), failing on the first violated rule:
 
 1. `stack.size() == 2`, else `SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH`.
@@ -117,7 +117,7 @@ RIP-25 outputs are native SegWit only.
 
 ### Pre-activation semantics
 
-Before `SCRIPT_VERIFY_PQ_HYBRID` is set, a witness v2 / 32-byte-program output is treated as an
+Before `SCRIPT_VERIFY_MLDSA44` is set, a witness v2 / 32-byte-program output is treated as an
 unknown future upgrade and is **anyone-can-spend** at the consensus layer (`interpreter.cpp:2031-2036`
 returns `true`), unless `SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM` is set (relay policy),
 in which case it returns `SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM`.
@@ -182,27 +182,50 @@ RIP-25 activates via BIP9 versionbits, deployment `mldsa44`, bit 11
 | regtest | `ALWAYS_ACTIVE` | 108 / 144 |
 
 When the deployment is active at a block, `GetBlockScriptFlags` adds
-`SCRIPT_VERIFY_PQ_HYBRID = 1U << 22` (`src/validation.cpp:2667-2670`, `interpreter.h:151-152`).
+`SCRIPT_VERIFY_MLDSA44 = 1U << 22` (`src/validation.cpp:2667-2670`, `interpreter.h:151-152`).
 
-> Note on naming: the flag is called `SCRIPT_VERIFY_PQ_HYBRID`, but the implemented rule is pure
-> ML-DSA-44 with no ECDSA component. A true hybrid scheme is a separate future output type.
+> The flag enforces pure ML-DSA-44 (no ECDSA component). A true hybrid (ECDSA+ML-DSA) scheme, if
+> ever added, would be a separate future output type with its own flag; this one is named
+> `SCRIPT_VERIFY_MLDSA44` accordingly.
 
-**Mempool vs consensus asymmetry:** `SCRIPT_VERIFY_PQ_HYBRID` is in `STANDARD_SCRIPT_VERIFY_FLAGS`
+**Mempool vs consensus asymmetry:** `SCRIPT_VERIFY_MLDSA44` is in `STANDARD_SCRIPT_VERIFY_FLAGS`
 but not `MANDATORY_SCRIPT_VERIFY_FLAGS` (`src/policy/policy.h`). The mempool therefore enforces
 RIP-25 verification on all networks regardless of activation, while consensus enforces it only once
 the deployment is active. This is documented so implementers do not rely on mempool acceptance as
 evidence of consensus validity before activation.
 
-## Resource limits and DoS (OPEN)
+## Resource limits and DoS
 
-> **OPEN (must resolve before freeze).** No PQ-specific cost accounting exists today. A witness v2
-> input contributes 0 sigops (`interpreter.cpp:2205-2219`), and `IsWitnessStandard`
-> (`src/policy/policy.cpp:264-330`) has no witness-v2 branch, so the 2420/1312-byte elements bypass
-> the standard 80-byte stack-item limit. An ML-DSA-44 verification is CPU-heavy yet currently free
-> against every limit. Before freeze the specification MUST define at least: maximum PQ
-> verifications per transaction and per block, maximum PQ witness element and total witness size,
-> mempool admission caps, and a minimum relay fee floor sized so a ~3.7 KB spend plus its
-> verification cannot be purchased too cheaply.
+A measured ML-DSA-44 verification costs ~16.5 microseconds, which is *cheaper* than an ECDSA
+verification (~50 us). The dominant cost of a RIP-25 input is its size: the ~3.7 KB witness
+(2420 + 1312 bytes) is already accounted for by transaction weight, and `MAX_BLOCK_WEIGHT` alone
+bounds a block to roughly 2000 PQ verifications (~35 ms), which is well within the range the network
+already tolerates for ECDSA. RIP-25 is therefore not a validation-time DoS vector on its own.
+
+To make that bound explicit and to price the operation, each active ML-DSA-44 verification is charged
+a **sigop cost** (`MLDSA44_SIGOP_COST = 50`, `src/script/script.h`), counted in `WitnessSigOps`
+(`src/script/interpreter.cpp`) only when `SCRIPT_VERIFY_MLDSA44` is set. Charging it through the
+existing sigop machinery reuses three limits at once, with no parallel accounting system:
+
+- **Per block:** it counts toward `MAX_BLOCK_SIGOPS_COST` (80000), capping a block at 1600 PQ
+  verifications.
+- **Per transaction (policy):** it counts toward `MAX_STANDARD_TX_SIGOPS_COST` (16000), capping a
+  standard transaction at 320 PQ verifications.
+- **Fees:** `DEFAULT_BYTES_PER_SIGOP` inflates the virtual size by the sigop count, so a PQ spend
+  pays a fee commensurate with its verification, not only its weight.
+
+The value 50 matches the Tapscript per-checksig cost (`VALIDATION_WEIGHT_PER_SIGOP_PASSED`); it is a
+conservative over-pricing given the measured ~16.5 us, chosen for a clean, consistent ceiling.
+Because the charge is gated on `SCRIPT_VERIFY_MLDSA44`, pre-activation cost accounting is unchanged.
+
+**Standardness.** `IsWitnessStandard` (`src/policy/policy.cpp`) has a witness-v2 branch requiring the
+witness to be exactly the canonical `[signature (2420), public_key (1312)]`; any other shape is
+non-standard and does not relay, so oversized or padded v2 witnesses cannot bloat the mempool. Both
+the sigop cost and the standardness branch are covered by `mldsa44_sighash_tests.cpp`.
+
+> A dedicated hybrid signature (a real ML-DSA + ECDSA output) would carry two signatures and could
+> warrant a higher per-verification charge; that is a separate future output type and out of scope
+> here.
 
 ## Domain separation
 
@@ -240,8 +263,10 @@ consensus. Enforced by `mldsa44_sighash_tests.cpp` (`domain_separation_binds_the
    `"AVN/RIP-25/ML-DSA-44/v1/" || genesis_block_hash`, set once from the active network in
    `SelectParams()` and shared by signer and verifier, giving explicit per-network binding (see
    Domain separation).
-3. **Resource limits:** define per-transaction and per-block PQ verification and size limits (see
-   Resource limits).
+3. **Resource limits:** RESOLVED. Each active ML-DSA-44 verification is charged
+   `MLDSA44_SIGOP_COST = 50` sigops, bounding a block to 1600 and a standard transaction to 320 PQ
+   verifications and tying fees to the cost; `IsWitnessStandard` requires the canonical two-element
+   witness (see Resource limits and DoS).
 4. **Sighash policy:** RESOLVED. `SIGHASH_ALL | SIGHASH_FORKID` is the permanent and only rule; no
    sighash-type byte is carried in the witness. The two magic `0x41` literals are replaced by the
    named `SIGHASH_ALL | SIGHASH_FORKID` on both the signing and verifying sides, and the rule is

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -216,10 +216,13 @@ evidence of consensus validity before activation.
 3. **Resource limits:** define per-transaction and per-block PQ verification and size limits (see
    Resource limits).
 4. **Sighash policy:** confirm `SIGHASH_ALL | SIGHASH_FORKID` only is the permanent rule.
-5. **liboqs requirement:** an activated node built without liboqs currently fails every PQ
-   signature (`src/crypto/mldsa.cpp:120-137` stub returns `false`), and the build silently
-   downgrades `WITH_LIBOQS=OFF` on a warning (`cmake/liboqs.cmake`). Before freeze, liboqs MUST be
-   a hard build requirement for any release capable of activation, and its exact revision pinned.
+5. **liboqs requirement:** PARTIALLY RESOLVED. The build no longer silently downgrades: with
+   `WITH_LIBOQS` ON (the default) a missing liboqs is now a `FATAL_ERROR`, and disabling
+   post-quantum support requires an explicit `-DWITH_LIBOQS=OFF` (`cmake/liboqs.cmake`). The stub
+   verifier still returns `false` when built that way (`src/crypto/mldsa.cpp`), so such a binary
+   must not act as a validating node after activation. Remaining before freeze: pin liboqs to an
+   exact revision (currently the 0.12.0 tag plus sha256 in `depends/packages/liboqs.mk`) and assert
+   the release build cannot reach the stub path.
 
 ## Test vectors
 

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -119,7 +119,7 @@ Consequence: **RIP-25 outputs created before activation are not secure and must 
 hold value on mainnet.** The wallet enforces this by refusing to generate `pq` addresses until the
 deployment is active (`src/wallet/rpc/addresses.cpp:69-75`).
 
-### Key derivation (OPEN)
+### Key derivation
 
 Wallets derive ML-DSA-44 keys through a descriptor:
 
@@ -128,17 +128,40 @@ mldsa44(<xpub>/25h/921h/0h/<0h|1h>/*h)         (purpose 25 = RIP-25, coin type 9
 ```
 
 All steps are hardened; the final step must be `/*h` (`src/script/descriptor.cpp:2678-2717`,
-`src/wallet/walletutil.cpp:63-75`). The 32-byte hardened BIP32 child private key at the leaf is
-used as the ML-DSA-44 seed.
+`src/wallet/walletutil.cpp:63-75`). Let `leaf` be the 32-byte hardened BIP32 child private key at
+the leaf. The keypair is then derived by this exact, normative algorithm:
 
-> **OPEN (must resolve before freeze).** The current seed-to-keypair step is not a
-> FIPS-204-standard derandomized keygen. Because liboqs 0.12.0 does not export a public
-> derandomized keypair function, `src/crypto/mldsa.cpp:36-82` temporarily replaces liboqs's global
-> RNG with a SHA256 counter-mode KDF to force determinism. This couples every address to liboqs's
-> internal RNG call pattern and has no known-answer coverage. Before freeze this MUST be replaced
-> with a written, standards-aligned derandomized keygen (upgrade liboqs to expose
-> `OQS_SIG_ml_dsa_44_keypair_derand`, or vendor a minimal FIPS-204 keygen) and pinned with the
-> test vectors below. The exact byte-level derivation becomes normative here.
+```
+DST = "AVN/RIP-25/ML-DSA-44/keygen/v1"        (30 ASCII bytes, no trailing NUL)
+xi  = SHA256( DST || leaf )                    32-byte ML-DSA seed
+(public_key, secret_key) = ML-DSA.KeyGen_internal(xi)   (FIPS 204 Algorithm 6)
+```
+
+`ML-DSA.KeyGen_internal` is the standard derandomized FIPS-204 key generation: `xi` is expanded as
+`SHAKE256(xi || IntToBytes(k=4,1) || IntToBytes(l=4,1))` into `(rho, rho', K)`, the matrix `A` is
+expanded from `rho`, the short vectors `s1, s2` are sampled from `rho'`, `t = A*s1 + s2` is split
+into `(t1, t0)`, and `public_key = pkEncode(rho, t1)`,
+`secret_key = skEncode(rho, tr, K, s1, s2, t0)` with `tr = SHAKE256(public_key)`. Because the
+result is a standard function of `xi`, any compliant ML-DSA implementation reproduces the same
+keypair; the derivation is independent of how randomness is drawn.
+
+The versioned domain-separation tag (`.../v1`) makes the derivation explicit and lets any future
+change be unambiguous (`.../v2`). The mapping is pinned by the known-answer vector below and by
+`derivation_known_answer_vector` in `src/test/pqkey_tests.cpp`, so it cannot drift silently across a
+liboqs upgrade, a struct-ABI change, or a change to the tag or the expansion.
+
+Implementation: `src/crypto/mldsa.cpp` `KeyGenFromSeed` computes `xi` and runs `KeyGen_internal` by
+calling the pinned liboqs reference primitives (`pqcrystals_ml_dsa_44_ref_*`) directly with `xi`,
+with no process-global RNG state and no mutex. This replaces the earlier approach, which forced
+determinism by temporarily swapping liboqs's global RNG for a SHA256 counter-mode KDF and so coupled
+every address to liboqs's internal RNG call order.
+
+Reference known-answer vector (`leaf = 0x00,0x01,...,0x1f`):
+
+```
+witness_program = SHA256(public_key) = e7fb04e58cb66a825e9f045ea60e6a6d72bbefddb93343321bc64cd03c4265b2
+SHA256(secret_key)                   = 5e6259e974035d534b5007ee56b08beaf8d91a31d593cb786c8eede792e1b1c8
+```
 
 ## Activation
 
@@ -186,8 +209,9 @@ evidence of consensus validity before activation.
 
 ## Open decisions (consolidated, must resolve before freeze)
 
-1. **Key derivation:** replace the liboqs-RNG-hijack with a written derandomized keygen and pin it
-   with vectors (see Key derivation).
+1. **Key derivation:** RESOLVED. The liboqs-RNG-hijack is replaced by an explicit, versioned,
+   standards-aligned derandomized keygen (`xi = SHA256(DST || leaf)`, then FIPS-204
+   `KeyGen_internal(xi)`), pinned by a known-answer vector (see Key derivation).
 2. **Domain separation:** add an explicit context/network separator (see Domain separation).
 3. **Resource limits:** define per-transaction and per-block PQ verification and size limits (see
    Resource limits).

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -79,8 +79,14 @@ scriptCode = OP_2 <program>                    (34 bytes)
 sighash    = SignatureHash(scriptCode, tx, nIn, 0x41, amount, SigVersion::WITNESS_V0, txdata)
 ```
 
-- The sighash type is hardcoded to `SIGHASH_ALL | SIGHASH_FORKID` (`0x41`). No other sighash modes
-  are supported, and no sighash byte is carried in the witness. See **OPEN: sighash policy**.
+- The sighash type is fixed to `SIGHASH_ALL | SIGHASH_FORKID` (`0x41`) and is not encoded anywhere
+  in the transaction. No other sighash mode is valid, and unlike ECDSA/Schnorr the witness carries
+  **no** trailing sighash-type byte: the signature element is the bare `SIG_SIZE` (2420-byte) ML-DSA
+  signature. A verifier MUST reject any witness whose signature element is not exactly 2420 bytes
+  (`SCRIPT_ERR_PQ_SIGNATURE_SIZE`), which is what enforces the "no carried byte" half of this rule;
+  a signature computed over any other hashtype's digest fails verification
+  (`SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED`). Both halves are locked by
+  `mldsa44_sighash_tests.cpp`.
 - `amount` is the value of the output being spent (BIP143).
 - Using the 34-byte `OP_2 <program>` scriptCode distinguishes a RIP-25 preimage from a witness v0
   (P2WPKH/P2WSH) preimage, because a v0 scriptCode can never take that shape.
@@ -215,7 +221,10 @@ evidence of consensus validity before activation.
 2. **Domain separation:** add an explicit context/network separator (see Domain separation).
 3. **Resource limits:** define per-transaction and per-block PQ verification and size limits (see
    Resource limits).
-4. **Sighash policy:** confirm `SIGHASH_ALL | SIGHASH_FORKID` only is the permanent rule.
+4. **Sighash policy:** RESOLVED. `SIGHASH_ALL | SIGHASH_FORKID` is the permanent and only rule; no
+   sighash-type byte is carried in the witness. The two magic `0x41` literals are replaced by the
+   named `SIGHASH_ALL | SIGHASH_FORKID` on both the signing and verifying sides, and the rule is
+   locked behaviorally by `mldsa44_sighash_tests.cpp` (see Signature message).
 5. **liboqs requirement:** PARTIALLY RESOLVED. The build no longer silently downgrades: with
    `WITH_LIBOQS` ON (the default) a missing liboqs is now a `FATAL_ERROR`, and disabling
    post-quantum support requires an explicit `-DWITH_LIBOQS=OFF` (`cmake/liboqs.cmake`). The stub

--- a/doc/rip-25.md
+++ b/doc/rip-25.md
@@ -139,7 +139,7 @@ All steps are hardened; the final step must be `/*h` (`src/script/descriptor.cpp
 the leaf. The keypair is then derived by this exact, normative algorithm:
 
 ```
-DST = "AVN/RIP-25/ML-DSA-44/keygen/v1"        (30 ASCII bytes, no trailing NUL)
+DST = "AVN/ML-DSA-44/keygen/v1"        (23 ASCII bytes, no trailing NUL)
 xi  = SHA256( DST || leaf )                    32-byte ML-DSA seed
 (public_key, secret_key) = ML-DSA.KeyGen_internal(xi)   (FIPS 204 Algorithm 6)
 ```
@@ -155,19 +155,23 @@ keypair; the derivation is independent of how randomness is drawn.
 The versioned domain-separation tag (`.../v1`) makes the derivation explicit and lets any future
 change be unambiguous (`.../v2`). The mapping is pinned by the known-answer vector below and by
 `derivation_known_answer_vector` in `src/test/pqkey_tests.cpp`, so it cannot drift silently across a
-liboqs upgrade, a struct-ABI change, or a change to the tag or the expansion.
+liboqs upgrade or a change to the tag.
 
-Implementation: `src/crypto/mldsa.cpp` `KeyGenFromSeed` computes `xi` and runs `KeyGen_internal` by
-calling the pinned liboqs reference primitives (`pqcrystals_ml_dsa_44_ref_*`) directly with `xi`,
-with no process-global RNG state and no mutex. This replaces the earlier approach, which forced
-determinism by temporarily swapping liboqs's global RNG for a SHA256 counter-mode KDF and so coupled
-every address to liboqs's internal RNG call order.
+Implementation: `src/crypto/mldsa.cpp` `KeyGenFromSeed` computes `xi` and runs FIPS-204
+`KeyGen_internal(xi)` through liboqs's single seeded-keygen entry point
+(`..._keypair_internal(pk, sk, seed)`, mldsa-native backend, liboqs >= 0.16), a standardized
+byte-buffer contract with no struct-ABI coupling. liboqs exposes no public seeded keypair, so this
+one internal symbol is the only such dependency; sign and verify use the public context-string API.
+Because `KeyGen_internal(xi)` is standardized, the output was confirmed byte-identical across the
+0.12.0 pqcrystals backend and the 0.16.0 mldsa-native backend. This replaces the original approach,
+which forced determinism by temporarily swapping liboqs's global RNG for a SHA256 counter-mode KDF
+and so coupled every address to liboqs's internal RNG call order.
 
 Reference known-answer vector (`leaf = 0x00,0x01,...,0x1f`):
 
 ```
-witness_program = SHA256(public_key) = e7fb04e58cb66a825e9f045ea60e6a6d72bbefddb93343321bc64cd03c4265b2
-SHA256(secret_key)                   = 5e6259e974035d534b5007ee56b08beaf8d91a31d593cb786c8eede792e1b1c8
+witness_program = SHA256(public_key) = a7da36522f995f7a2ccba0e8d10f6b7d2dcd7882486a38462176ba720823a0fb
+SHA256(secret_key)                   = f59fd75b78cb6727f9c626dc82898ce6b5f8794418708330e686a1e1a5fc4099
 ```
 
 ## Activation
@@ -234,7 +238,7 @@ native context string (the `pre = 0x00 || len(ctx) || ctx` prefix prepended to t
 signing and verification). The context is:
 
 ```
-ctx = "AVN/RIP-25/ML-DSA-44/v1/" || genesis_block_hash        (24 + 32 = 56 bytes)
+ctx = "AVN/ML-DSA-44/v1/" || genesis_block_hash        (24 + 32 = 56 bytes)
 ```
 
 The genesis block hash is the canonical, immutable per-network identifier, so a signature made for
@@ -260,7 +264,7 @@ consensus. Enforced by `mldsa44_sighash_tests.cpp` (`domain_separation_binds_the
    standards-aligned derandomized keygen (`xi = SHA256(DST || leaf)`, then FIPS-204
    `KeyGen_internal(xi)`), pinned by a known-answer vector (see Key derivation).
 2. **Domain separation:** RESOLVED. Every signature is bound to a FIPS-204 context string
-   `"AVN/RIP-25/ML-DSA-44/v1/" || genesis_block_hash`, set once from the active network in
+   `"AVN/ML-DSA-44/v1/" || genesis_block_hash`, set once from the active network in
    `SelectParams()` and shared by signer and verifier, giving explicit per-network binding (see
    Domain separation).
 3. **Resource limits:** RESOLVED. Each active ML-DSA-44 verification is charged
@@ -276,7 +280,7 @@ consensus. Enforced by `mldsa44_sighash_tests.cpp` (`domain_separation_binds_the
    - **Build:** with `WITH_LIBOQS` ON (the default) a missing liboqs is a `FATAL_ERROR`; disabling
      post-quantum support requires an explicit `-DWITH_LIBOQS=OFF` (`cmake/liboqs.cmake`).
    - **Pin:** liboqs is pinned by exact version plus tarball SHA-256 in `depends/packages/liboqs.mk`
-     (`0.12.0`, `df9999...9c08`), verified against the downloaded artifact, so the depends build is
+     (`0.16.0`, `162d5b...01eae`), verified against the downloaded artifact, so the depends build is
      reproducible and rejects any tampered source.
    - **Runtime:** `AppInitSanityChecks` refuses to start (via `mldsa::IsAvailable()`) when the build
      lacks liboqs and the selected network's `DEPLOYMENT_MLDSA44` is not `NEVER_ACTIVE`. A stub

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -11,6 +11,7 @@
 #include <consensus/params.h>
 #include <deploymentinfo.h>
 #include <logging.h>
+#include <script/interpreter.h>
 #include <tinyformat.h>
 #include <util/chaintype.h>
 #include <util/strencodings.h>
@@ -149,4 +150,21 @@ void SelectParams(const ChainType chain)
     SetPoWHashParams(
         consensus.vUpgrades[Consensus::UPGRADE_X16RT_SWITCH].nTimestamp,
         consensus.vUpgrades[Consensus::UPGRADE_DUAL_ALGO].nTimestamp);
+
+    // RIP-25: bind ML-DSA-44 signatures to this network. The context is
+    //   "AVN/RIP-25/ML-DSA-44/v1/" || genesis block hash (32 bytes).
+    // The genesis hash is the canonical, immutable per-network identifier, so a
+    // signature made for one network cannot verify on another. This is set here,
+    // the single choke point for network selection (node and tests alike), so
+    // the consensus verifier and the signer share one value; see
+    // GetMLDsa44DomainContext() in script/interpreter.h.
+    {
+        static constexpr char PQ_DST[] = "AVN/RIP-25/ML-DSA-44/v1/";
+        const uint256& genesis = consensus.hashGenesisBlock;
+        std::vector<unsigned char> ctx;
+        ctx.reserve(sizeof(PQ_DST) - 1 + genesis.size());
+        ctx.insert(ctx.end(), PQ_DST, PQ_DST + sizeof(PQ_DST) - 1);
+        ctx.insert(ctx.end(), genesis.begin(), genesis.end());
+        SetMLDsa44DomainContext(ctx);
+    }
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -152,14 +152,14 @@ void SelectParams(const ChainType chain)
         consensus.vUpgrades[Consensus::UPGRADE_DUAL_ALGO].nTimestamp);
 
     // RIP-25: bind ML-DSA-44 signatures to this network. The context is
-    //   "AVN/RIP-25/ML-DSA-44/v1/" || genesis block hash (32 bytes).
+    //   "AVN/ML-DSA-44/v1/" || genesis block hash (32 bytes).
     // The genesis hash is the canonical, immutable per-network identifier, so a
     // signature made for one network cannot verify on another. This is set here,
     // the single choke point for network selection (node and tests alike), so
     // the consensus verifier and the signer share one value; see
     // GetMLDsa44DomainContext() in script/interpreter.h.
     {
-        static constexpr char PQ_DST[] = "AVN/RIP-25/ML-DSA-44/v1/";
+        static constexpr char PQ_DST[] = "AVN/ML-DSA-44/v1/";
         const uint256& genesis = consensus.hashGenesisBlock;
         std::vector<unsigned char> ctx;
         ctx.reserve(sizeof(PQ_DST) - 1 + genesis.size());

--- a/src/crypto/mldsa.cpp
+++ b/src/crypto/mldsa.cpp
@@ -13,13 +13,15 @@
 #endif
 
 #include <crypto/sha256.h>
-#include <algorithm>
+#include <support/cleanse.h>
 #include <cstring>
-#include <mutex>
 
 namespace mldsa {
 
 #ifdef HAVE_LIBOQS
+
+static_assert(PUBKEY_SIZE == 1312 && SECRETKEY_SIZE == 2560 && SEED_SIZE == 32,
+              "RIP-25 keygen assumes ML-DSA-44 (FIPS 204 parameter set I) sizes");
 
 namespace {
 
@@ -33,34 +35,54 @@ struct OqsSig {
     bool ok() const { return sig != nullptr; }
 };
 
-// ---- Deterministic RNG state for KeyGenFromSeed ----------------------------
-// liboqs 0.12.0 does not expose OQS_SIG_ml_dsa_44_keypair_derand publicly.
-// We achieve deterministic key generation by temporarily replacing the global
-// liboqs RNG with a SHA256-based counter-mode KDF seeded from the provided
-// 32-byte seed.  Access is serialised by s_derand_mutex so that this
-// manipulation of global OQS RNG state is thread-safe.
+// ---- Seeded FIPS-204 key generation ---------------------------------------
+// liboqs 0.12.0 exposes no OQS_SIG_ml_dsa_44_keypair_derand, and the vendored
+// pqcrystals reference implementation has no public keypair_internal entry
+// point.  The previous approach hijacked the process-global liboqs RNG with a
+// SHA256 counter-mode KDF: it worked only because keypair() happens to draw
+// exactly 32 bytes in a single randombytes() call, it needed a mutex around a
+// global, and any change to that call order in a future liboqs would have
+// silently produced different (unrecoverable) keys.
+//
+// Instead we reproduce pqcrystals crypto_sign_keypair (sign.c) verbatim,
+// replacing only its randombytes() draw with a seed we control, by calling the
+// reference implementation's own exported lattice primitives.  The output is
+// therefore byte-for-byte FIPS-204 ML-DSA.KeyGen_internal(xi) with no global
+// state, no mutex, and no dependence on liboqs's RNG call order.  A change in
+// liboqs's internal ABI would break the build (link/type error) or be caught
+// by the RIP-25 known-answer vector in pqkey_tests.cpp, never silently alter a
+// derived key.
+//
+// The symbol names below are exactly those exported by liboqs.a
+// (verified with nm: pqcrystals_ml_dsa_44_ref_*).
 
-static std::mutex s_derand_mutex;
-static const uint8_t* s_derand_seed = nullptr;
-static uint32_t s_derand_ctr = 0;
+extern "C" {
+    // Reference-implementation data types (params.h / poly.h / polyvec.h).
+    // ML-DSA-44: N=256, K=4, L=4.  Layouts copied verbatim; the static_assert
+    // above plus the KAT guard against any drift.
+    typedef struct { int32_t coeffs[256]; } ref_poly;
+    typedef struct { ref_poly vec[4]; }     ref_polyvecl;
+    typedef struct { ref_poly vec[4]; }     ref_polyveck;
 
-// Plain function pointer (no captures) required by OQS_randombytes_custom_algorithm.
-void DerandRNG(uint8_t* out, size_t len)
-{
-    uint8_t block[32 + sizeof(uint32_t)];
-    std::memcpy(block, s_derand_seed, 32);
-    while (len > 0) {
-        std::memcpy(block + 32, &s_derand_ctr, sizeof(s_derand_ctr));
-        uint8_t hash[CSHA256::OUTPUT_SIZE];
-        CSHA256().Write(block, sizeof(block)).Finalize(hash);
-        size_t chunk = std::min(len, sizeof(hash));
-        std::memcpy(out, hash, chunk);
-        out += chunk;
-        len -= chunk;
-        ++s_derand_ctr;
-    }
+    void pqcrystals_ml_dsa_44_ref_polyvec_matrix_expand(ref_polyvecl mat[4], const uint8_t rho[32]);
+    void pqcrystals_ml_dsa_44_ref_polyvecl_uniform_eta(ref_polyvecl* v, const uint8_t seed[64], uint16_t nonce);
+    void pqcrystals_ml_dsa_44_ref_polyveck_uniform_eta(ref_polyveck* v, const uint8_t seed[64], uint16_t nonce);
+    void pqcrystals_ml_dsa_44_ref_polyvecl_ntt(ref_polyvecl* v);
+    void pqcrystals_ml_dsa_44_ref_polyvec_matrix_pointwise_montgomery(ref_polyveck* t, const ref_polyvecl mat[4], const ref_polyvecl* v);
+    void pqcrystals_ml_dsa_44_ref_polyveck_reduce(ref_polyveck* v);
+    void pqcrystals_ml_dsa_44_ref_polyveck_invntt_tomont(ref_polyveck* v);
+    void pqcrystals_ml_dsa_44_ref_polyveck_add(ref_polyveck* w, const ref_polyveck* u, const ref_polyveck* v);
+    void pqcrystals_ml_dsa_44_ref_polyveck_caddq(ref_polyveck* v);
+    void pqcrystals_ml_dsa_44_ref_polyveck_power2round(ref_polyveck* v1, ref_polyveck* v0, const ref_polyveck* v);
+    void pqcrystals_ml_dsa_44_ref_pack_pk(uint8_t pk[1312], const uint8_t rho[32], const ref_polyveck* t1);
+    void pqcrystals_ml_dsa_44_ref_pack_sk(uint8_t sk[2560], const uint8_t rho[32], const uint8_t tr[64],
+                                          const uint8_t key[32], const ref_polyveck* t0,
+                                          const ref_polyvecl* s1, const ref_polyveck* s2);
+
+    // Top-level liboqs SHAKE256 (FIPS 202 XOF).  Exported by liboqs.a but not
+    // present in the installed public headers, so declared here.
+    void OQS_SHA3_shake256(uint8_t* output, size_t outlen, const uint8_t* input, size_t inlen);
 }
-// ---------------------------------------------------------------------------
 
 } // namespace
 
@@ -68,17 +90,70 @@ bool KeyGenFromSeed(std::span<uint8_t, PUBKEY_SIZE> pubkey,
                     std::span<uint8_t, SECRETKEY_SIZE> seckey,
                     std::span<const uint8_t, SEED_SIZE> seed)
 {
-    // Use OQS_randombytes_custom_algorithm to inject a deterministic
-    // SHA256 counter-mode KDF so that keypair generation is reproducible
-    // from the same seed without requiring _derand or NIST KAT DRBG symbols.
-    std::lock_guard<std::mutex> lock(s_derand_mutex);
-    s_derand_seed = seed.data();
-    s_derand_ctr  = 0;
-    OQS_randombytes_custom_algorithm(DerandRNG);
-    OQS_STATUS rc = OQS_SIG_ml_dsa_44_keypair(pubkey.data(), seckey.data());
-    OQS_randombytes_switch_algorithm(OQS_RAND_alg_system);
-    s_derand_seed = nullptr;
-    return rc == OQS_SUCCESS;
+    // RIP-25 key derivation (normative; see doc/rip-25.md):
+    //   xi        = SHA256( DST || seed )                    32-byte ML-DSA seed
+    //   (pk, sk)  = ML-DSA.KeyGen_internal(xi)               FIPS 204 Alg. 6
+    // The versioned domain-separation tag makes the derivation an explicit,
+    // written algorithm rather than a side effect of liboqs internals, and
+    // lets any future change to it be unambiguous (…/v2).
+    static constexpr char DST[] = "AVN/RIP-25/ML-DSA-44/keygen/v1";
+    uint8_t xi[SEED_SIZE];
+    CSHA256()
+        .Write(reinterpret_cast<const uint8_t*>(DST), sizeof(DST) - 1)
+        .Write(seed.data(), seed.size())
+        .Finalize(xi);
+
+    // Expand xi into (rho, rhoprime, key) exactly as pqcrystals
+    // crypto_sign_keypair: SHAKE256( xi || K || L ) -> 128 bytes.
+    uint8_t exp_in[SEED_SIZE + 2];
+    std::memcpy(exp_in, xi, SEED_SIZE);
+    exp_in[SEED_SIZE + 0] = 4;  // K
+    exp_in[SEED_SIZE + 1] = 4;  // L
+    uint8_t exp_out[2 * SEED_SIZE + 64];  // rho(32) || rhoprime(64) || key(32)
+    OQS_SHA3_shake256(exp_out, sizeof(exp_out), exp_in, sizeof(exp_in));
+    const uint8_t* rho      = exp_out;
+    const uint8_t* rhoprime = exp_out + SEED_SIZE;
+    const uint8_t* key      = exp_out + SEED_SIZE + 64;
+
+    ref_polyvecl mat[4];
+    ref_polyvecl s1, s1hat;
+    ref_polyveck s2, t1, t0;
+
+    // Expand matrix A from rho.
+    pqcrystals_ml_dsa_44_ref_polyvec_matrix_expand(mat, rho);
+
+    // Sample short vectors s1, s2 from rhoprime (nonces 0..L-1 for s1, L.. for s2).
+    pqcrystals_ml_dsa_44_ref_polyvecl_uniform_eta(&s1, rhoprime, 0);
+    pqcrystals_ml_dsa_44_ref_polyveck_uniform_eta(&s2, rhoprime, 4);  // nonce = L
+
+    // t = A*s1 + s2.
+    s1hat = s1;
+    pqcrystals_ml_dsa_44_ref_polyvecl_ntt(&s1hat);
+    pqcrystals_ml_dsa_44_ref_polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    pqcrystals_ml_dsa_44_ref_polyveck_reduce(&t1);
+    pqcrystals_ml_dsa_44_ref_polyveck_invntt_tomont(&t1);
+    pqcrystals_ml_dsa_44_ref_polyveck_add(&t1, &t1, &s2);
+
+    // Split t into (t1, t0) and pack the public key.
+    pqcrystals_ml_dsa_44_ref_polyveck_caddq(&t1);
+    pqcrystals_ml_dsa_44_ref_polyveck_power2round(&t1, &t0, &t1);
+    pqcrystals_ml_dsa_44_ref_pack_pk(pubkey.data(), rho, &t1);
+
+    // tr = SHAKE256(pk); pack the secret key.
+    uint8_t tr[64];
+    OQS_SHA3_shake256(tr, sizeof(tr), pubkey.data(), PUBKEY_SIZE);
+    pqcrystals_ml_dsa_44_ref_pack_sk(seckey.data(), rho, tr, key, &t0, &s1, &s2);
+
+    // Wipe secret intermediates.
+    memory_cleanse(xi, sizeof(xi));
+    memory_cleanse(exp_in, sizeof(exp_in));
+    memory_cleanse(exp_out, sizeof(exp_out));
+    memory_cleanse(&s1, sizeof(s1));
+    memory_cleanse(&s1hat, sizeof(s1hat));
+    memory_cleanse(&s2, sizeof(s2));
+    memory_cleanse(&t0, sizeof(t0));
+    memory_cleanse(tr, sizeof(tr));
+    return true;
 }
 
 bool KeyGenRandom(std::span<uint8_t, PUBKEY_SIZE> pubkey,

--- a/src/crypto/mldsa.cpp
+++ b/src/crypto/mldsa.cpp
@@ -208,6 +208,8 @@ bool Verify(std::span<const uint8_t, SIG_SIZE> sig,
     return rc == 0;
 }
 
+bool IsAvailable() { return true; }
+
 #else // HAVE_LIBOQS not defined — stub implementations
 
 bool KeyGenFromSeed(std::span<uint8_t, PUBKEY_SIZE>, std::span<uint8_t, SECRETKEY_SIZE>,
@@ -224,6 +226,8 @@ bool Sign(std::span<uint8_t, SIG_SIZE>, std::span<const uint8_t>,
 bool Verify(std::span<const uint8_t, SIG_SIZE>, std::span<const uint8_t>,
             std::span<const uint8_t>, std::span<const uint8_t, PUBKEY_SIZE>)
 { return false; }
+
+bool IsAvailable() { return false; }
 
 #endif // HAVE_LIBOQS
 

--- a/src/crypto/mldsa.cpp
+++ b/src/crypto/mldsa.cpp
@@ -82,6 +82,20 @@ extern "C" {
     // Top-level liboqs SHAKE256 (FIPS 202 XOF).  Exported by liboqs.a but not
     // present in the installed public headers, so declared here.
     void OQS_SHA3_shake256(uint8_t* output, size_t outlen, const uint8_t* input, size_t inlen);
+
+    // Context-aware ML-DSA-44 sign/verify (FIPS 204 "pure" mode). liboqs 0.12.0
+    // exposes no context parameter through OQS_SIG_sign/verify, so we call the
+    // reference primitives directly. They prepend the standard domain framing
+    // pre = 0x00 || ctxlen || ctx before the message; with an empty ctx this is
+    // byte-identical to OQS_SIG_sign/verify. Both return 0 on success.
+    int pqcrystals_ml_dsa_44_ref_signature(uint8_t* sig, size_t* siglen,
+                                           const uint8_t* m, size_t mlen,
+                                           const uint8_t* ctx, size_t ctxlen,
+                                           const uint8_t* sk);
+    int pqcrystals_ml_dsa_44_ref_verify(const uint8_t* sig, size_t siglen,
+                                        const uint8_t* m, size_t mlen,
+                                        const uint8_t* ctx, size_t ctxlen,
+                                        const uint8_t* pk);
 }
 
 } // namespace
@@ -167,29 +181,31 @@ bool KeyGenRandom(std::span<uint8_t, PUBKEY_SIZE> pubkey,
 
 bool Sign(std::span<uint8_t, SIG_SIZE> sig,
           std::span<const uint8_t> msg,
+          std::span<const uint8_t> ctx,
           std::span<const uint8_t, SECRETKEY_SIZE> seckey)
 {
-    OqsSig ctx;
-    if (!ctx.ok()) return false;
-    size_t sig_len = SIG_SIZE;
-    OQS_STATUS rc = OQS_SIG_sign(ctx.sig,
-                                 sig.data(), &sig_len,
-                                 msg.data(), msg.size(),
-                                 seckey.data());
-    return rc == OQS_SUCCESS && sig_len == SIG_SIZE;
+    if (ctx.size() > 255) return false;  // FIPS 204 context-string limit
+    size_t sig_len = 0;
+    int rc = pqcrystals_ml_dsa_44_ref_signature(
+        sig.data(), &sig_len,
+        msg.data(), msg.size(),
+        ctx.data(), ctx.size(),
+        seckey.data());
+    return rc == 0 && sig_len == SIG_SIZE;
 }
 
 bool Verify(std::span<const uint8_t, SIG_SIZE> sig,
             std::span<const uint8_t> msg,
+            std::span<const uint8_t> ctx,
             std::span<const uint8_t, PUBKEY_SIZE> pubkey)
 {
-    OqsSig ctx;
-    if (!ctx.ok()) return false;
-    OQS_STATUS rc = OQS_SIG_verify(ctx.sig,
-                                   msg.data(), msg.size(),
-                                   sig.data(), SIG_SIZE,
-                                   pubkey.data());
-    return rc == OQS_SUCCESS;
+    if (ctx.size() > 255) return false;
+    int rc = pqcrystals_ml_dsa_44_ref_verify(
+        sig.data(), SIG_SIZE,
+        msg.data(), msg.size(),
+        ctx.data(), ctx.size(),
+        pubkey.data());
+    return rc == 0;
 }
 
 #else // HAVE_LIBOQS not defined — stub implementations
@@ -202,11 +218,11 @@ bool KeyGenRandom(std::span<uint8_t, PUBKEY_SIZE>, std::span<uint8_t, SECRETKEY_
 { return false; }
 
 bool Sign(std::span<uint8_t, SIG_SIZE>, std::span<const uint8_t>,
-          std::span<const uint8_t, SECRETKEY_SIZE>)
+          std::span<const uint8_t>, std::span<const uint8_t, SECRETKEY_SIZE>)
 { return false; }
 
 bool Verify(std::span<const uint8_t, SIG_SIZE>, std::span<const uint8_t>,
-            std::span<const uint8_t, PUBKEY_SIZE>)
+            std::span<const uint8_t>, std::span<const uint8_t, PUBKEY_SIZE>)
 { return false; }
 
 #endif // HAVE_LIBOQS

--- a/src/crypto/mldsa.cpp
+++ b/src/crypto/mldsa.cpp
@@ -14,18 +14,17 @@
 
 #include <crypto/sha256.h>
 #include <support/cleanse.h>
-#include <cstring>
 
 namespace mldsa {
 
 #ifdef HAVE_LIBOQS
 
-static_assert(PUBKEY_SIZE == 1312 && SECRETKEY_SIZE == 2560 && SEED_SIZE == 32,
-              "RIP-25 keygen assumes ML-DSA-44 (FIPS 204 parameter set I) sizes");
+static_assert(PUBKEY_SIZE == 1312 && SECRETKEY_SIZE == 2560 && SIG_SIZE == 2420 && SEED_SIZE == 32,
+              "RIP-25 assumes ML-DSA-44 (FIPS 204 parameter set I) sizes");
 
 namespace {
 
-// RAII wrapper for OQS_SIG to ensure cleanup on all exit paths.
+// RAII wrapper for OQS_SIG (used only by KeyGenRandom).
 struct OqsSig {
     OQS_SIG* sig;
     explicit OqsSig() : sig(OQS_SIG_new(OQS_SIG_alg_ml_dsa_44)) {}
@@ -35,67 +34,17 @@ struct OqsSig {
     bool ok() const { return sig != nullptr; }
 };
 
-// ---- Seeded FIPS-204 key generation ---------------------------------------
-// liboqs 0.12.0 exposes no OQS_SIG_ml_dsa_44_keypair_derand, and the vendored
-// pqcrystals reference implementation has no public keypair_internal entry
-// point.  The previous approach hijacked the process-global liboqs RNG with a
-// SHA256 counter-mode KDF: it worked only because keypair() happens to draw
-// exactly 32 bytes in a single randombytes() call, it needed a mutex around a
-// global, and any change to that call order in a future liboqs would have
-// silently produced different (unrecoverable) keys.
-//
-// Instead we reproduce pqcrystals crypto_sign_keypair (sign.c) verbatim,
-// replacing only its randombytes() draw with a seed we control, by calling the
-// reference implementation's own exported lattice primitives.  The output is
-// therefore byte-for-byte FIPS-204 ML-DSA.KeyGen_internal(xi) with no global
-// state, no mutex, and no dependence on liboqs's RNG call order.  A change in
-// liboqs's internal ABI would break the build (link/type error) or be caught
-// by the RIP-25 known-answer vector in pqkey_tests.cpp, never silently alter a
-// derived key.
-//
-// The symbol names below are exactly those exported by liboqs.a
-// (verified with nm: pqcrystals_ml_dsa_44_ref_*).
-
+// FIPS-204 KeyGen_internal from liboqs's mldsa-native backend (liboqs >= 0.16).
+// liboqs exposes no public seeded keypair, so deterministic key generation calls
+// this one internal symbol: a standardized, deterministic seed -> (pk, sk)
+// contract over plain byte buffers, with no struct-ABI coupling. The portable
+// "_C_" reference is compiled on every platform (present in both dist and
+// non-dist builds) and produces byte-identical FIPS-204 output regardless of
+// CPU; the RIP-25 known-answer vector in pqkey_tests.cpp pins that output, so any
+// drift is caught at test time rather than silently changing derived keys.
+// (Sign/Verify below use the public OQS ctx-string API and need no internal symbol.)
 extern "C" {
-    // Reference-implementation data types (params.h / poly.h / polyvec.h).
-    // ML-DSA-44: N=256, K=4, L=4.  Layouts copied verbatim; the static_assert
-    // above plus the KAT guard against any drift.
-    typedef struct { int32_t coeffs[256]; } ref_poly;
-    typedef struct { ref_poly vec[4]; }     ref_polyvecl;
-    typedef struct { ref_poly vec[4]; }     ref_polyveck;
-
-    void pqcrystals_ml_dsa_44_ref_polyvec_matrix_expand(ref_polyvecl mat[4], const uint8_t rho[32]);
-    void pqcrystals_ml_dsa_44_ref_polyvecl_uniform_eta(ref_polyvecl* v, const uint8_t seed[64], uint16_t nonce);
-    void pqcrystals_ml_dsa_44_ref_polyveck_uniform_eta(ref_polyveck* v, const uint8_t seed[64], uint16_t nonce);
-    void pqcrystals_ml_dsa_44_ref_polyvecl_ntt(ref_polyvecl* v);
-    void pqcrystals_ml_dsa_44_ref_polyvec_matrix_pointwise_montgomery(ref_polyveck* t, const ref_polyvecl mat[4], const ref_polyvecl* v);
-    void pqcrystals_ml_dsa_44_ref_polyveck_reduce(ref_polyveck* v);
-    void pqcrystals_ml_dsa_44_ref_polyveck_invntt_tomont(ref_polyveck* v);
-    void pqcrystals_ml_dsa_44_ref_polyveck_add(ref_polyveck* w, const ref_polyveck* u, const ref_polyveck* v);
-    void pqcrystals_ml_dsa_44_ref_polyveck_caddq(ref_polyveck* v);
-    void pqcrystals_ml_dsa_44_ref_polyveck_power2round(ref_polyveck* v1, ref_polyveck* v0, const ref_polyveck* v);
-    void pqcrystals_ml_dsa_44_ref_pack_pk(uint8_t pk[1312], const uint8_t rho[32], const ref_polyveck* t1);
-    void pqcrystals_ml_dsa_44_ref_pack_sk(uint8_t sk[2560], const uint8_t rho[32], const uint8_t tr[64],
-                                          const uint8_t key[32], const ref_polyveck* t0,
-                                          const ref_polyvecl* s1, const ref_polyveck* s2);
-
-    // Top-level liboqs SHAKE256 (FIPS 202 XOF).  Exported by liboqs.a but not
-    // present in the installed public headers, so declared here.
-    void OQS_SHA3_shake256(uint8_t* output, size_t outlen, const uint8_t* input, size_t inlen);
-
-    // Context-aware ML-DSA-44 sign/verify (FIPS 204 "pure" mode). liboqs 0.12.0
-    // exposes no context parameter through OQS_SIG_sign/verify, so we call the
-    // reference primitives directly. They prepend the standard domain framing
-    // pre = 0x00 || ctxlen || ctx before the message; with an empty ctx this is
-    // byte-identical to OQS_SIG_sign/verify. Both return 0 on success.
-    int pqcrystals_ml_dsa_44_ref_signature(uint8_t* sig, size_t* siglen,
-                                           const uint8_t* m, size_t mlen,
-                                           const uint8_t* ctx, size_t ctxlen,
-                                           const uint8_t* sk);
-    int pqcrystals_ml_dsa_44_ref_verify(const uint8_t* sig, size_t siglen,
-                                        const uint8_t* m, size_t mlen,
-                                        const uint8_t* ctx, size_t ctxlen,
-                                        const uint8_t* pk);
+    int PQCP_MLDSA_NATIVE_MLDSA44_C_keypair_internal(uint8_t* pk, uint8_t* sk, const uint8_t* seed);
 }
 
 } // namespace
@@ -105,69 +54,20 @@ bool KeyGenFromSeed(std::span<uint8_t, PUBKEY_SIZE> pubkey,
                     std::span<const uint8_t, SEED_SIZE> seed)
 {
     // RIP-25 key derivation (normative; see doc/rip-25.md):
-    //   xi        = SHA256( DST || seed )                    32-byte ML-DSA seed
-    //   (pk, sk)  = ML-DSA.KeyGen_internal(xi)               FIPS 204 Alg. 6
+    //   xi        = SHA256( DST || seed )              32-byte ML-DSA seed
+    //   (pk, sk)  = ML-DSA.KeyGen_internal(xi)         FIPS 204 Algorithm 6
     // The versioned domain-separation tag makes the derivation an explicit,
-    // written algorithm rather than a side effect of liboqs internals, and
-    // lets any future change to it be unambiguous (…/v2).
-    static constexpr char DST[] = "AVN/RIP-25/ML-DSA-44/keygen/v1";
+    // written algorithm; a future change is unambiguous (…/v2).
+    static constexpr char DST[] = "AVN/ML-DSA-44/keygen/v1";
     uint8_t xi[SEED_SIZE];
     CSHA256()
         .Write(reinterpret_cast<const uint8_t*>(DST), sizeof(DST) - 1)
         .Write(seed.data(), seed.size())
         .Finalize(xi);
 
-    // Expand xi into (rho, rhoprime, key) exactly as pqcrystals
-    // crypto_sign_keypair: SHAKE256( xi || K || L ) -> 128 bytes.
-    uint8_t exp_in[SEED_SIZE + 2];
-    std::memcpy(exp_in, xi, SEED_SIZE);
-    exp_in[SEED_SIZE + 0] = 4;  // K
-    exp_in[SEED_SIZE + 1] = 4;  // L
-    uint8_t exp_out[2 * SEED_SIZE + 64];  // rho(32) || rhoprime(64) || key(32)
-    OQS_SHA3_shake256(exp_out, sizeof(exp_out), exp_in, sizeof(exp_in));
-    const uint8_t* rho      = exp_out;
-    const uint8_t* rhoprime = exp_out + SEED_SIZE;
-    const uint8_t* key      = exp_out + SEED_SIZE + 64;
-
-    ref_polyvecl mat[4];
-    ref_polyvecl s1, s1hat;
-    ref_polyveck s2, t1, t0;
-
-    // Expand matrix A from rho.
-    pqcrystals_ml_dsa_44_ref_polyvec_matrix_expand(mat, rho);
-
-    // Sample short vectors s1, s2 from rhoprime (nonces 0..L-1 for s1, L.. for s2).
-    pqcrystals_ml_dsa_44_ref_polyvecl_uniform_eta(&s1, rhoprime, 0);
-    pqcrystals_ml_dsa_44_ref_polyveck_uniform_eta(&s2, rhoprime, 4);  // nonce = L
-
-    // t = A*s1 + s2.
-    s1hat = s1;
-    pqcrystals_ml_dsa_44_ref_polyvecl_ntt(&s1hat);
-    pqcrystals_ml_dsa_44_ref_polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
-    pqcrystals_ml_dsa_44_ref_polyveck_reduce(&t1);
-    pqcrystals_ml_dsa_44_ref_polyveck_invntt_tomont(&t1);
-    pqcrystals_ml_dsa_44_ref_polyveck_add(&t1, &t1, &s2);
-
-    // Split t into (t1, t0) and pack the public key.
-    pqcrystals_ml_dsa_44_ref_polyveck_caddq(&t1);
-    pqcrystals_ml_dsa_44_ref_polyveck_power2round(&t1, &t0, &t1);
-    pqcrystals_ml_dsa_44_ref_pack_pk(pubkey.data(), rho, &t1);
-
-    // tr = SHAKE256(pk); pack the secret key.
-    uint8_t tr[64];
-    OQS_SHA3_shake256(tr, sizeof(tr), pubkey.data(), PUBKEY_SIZE);
-    pqcrystals_ml_dsa_44_ref_pack_sk(seckey.data(), rho, tr, key, &t0, &s1, &s2);
-
-    // Wipe secret intermediates.
+    const int rc = PQCP_MLDSA_NATIVE_MLDSA44_C_keypair_internal(pubkey.data(), seckey.data(), xi);
     memory_cleanse(xi, sizeof(xi));
-    memory_cleanse(exp_in, sizeof(exp_in));
-    memory_cleanse(exp_out, sizeof(exp_out));
-    memory_cleanse(&s1, sizeof(s1));
-    memory_cleanse(&s1hat, sizeof(s1hat));
-    memory_cleanse(&s2, sizeof(s2));
-    memory_cleanse(&t0, sizeof(t0));
-    memory_cleanse(tr, sizeof(tr));
-    return true;
+    return rc == 0;
 }
 
 bool KeyGenRandom(std::span<uint8_t, PUBKEY_SIZE> pubkey,
@@ -186,12 +86,12 @@ bool Sign(std::span<uint8_t, SIG_SIZE> sig,
 {
     if (ctx.size() > 255) return false;  // FIPS 204 context-string limit
     size_t sig_len = 0;
-    int rc = pqcrystals_ml_dsa_44_ref_signature(
+    OQS_STATUS rc = OQS_SIG_ml_dsa_44_sign_with_ctx_str(
         sig.data(), &sig_len,
         msg.data(), msg.size(),
         ctx.data(), ctx.size(),
         seckey.data());
-    return rc == 0 && sig_len == SIG_SIZE;
+    return rc == OQS_SUCCESS && sig_len == SIG_SIZE;
 }
 
 bool Verify(std::span<const uint8_t, SIG_SIZE> sig,
@@ -200,12 +100,12 @@ bool Verify(std::span<const uint8_t, SIG_SIZE> sig,
             std::span<const uint8_t, PUBKEY_SIZE> pubkey)
 {
     if (ctx.size() > 255) return false;
-    int rc = pqcrystals_ml_dsa_44_ref_verify(
-        sig.data(), SIG_SIZE,
+    OQS_STATUS rc = OQS_SIG_ml_dsa_44_verify_with_ctx_str(
         msg.data(), msg.size(),
+        sig.data(), SIG_SIZE,
         ctx.data(), ctx.size(),
         pubkey.data());
-    return rc == 0;
+    return rc == OQS_SUCCESS;
 }
 
 bool IsAvailable() { return true; }

--- a/src/crypto/mldsa.h
+++ b/src/crypto/mldsa.h
@@ -24,7 +24,11 @@ static constexpr size_t SIG_SIZE       = 2420;
 static constexpr size_t SEED_SIZE      = 32;   // Deterministic keygen seed
 
 /**
- * Generate an ML-DSA-44 keypair from a 32-byte seed.
+ * Deterministically derive an ML-DSA-44 keypair from a 32-byte seed.
+ * The seed is domain-separated and expanded to the FIPS 204 keygen seed xi
+ * (xi = SHA256("AVN/RIP-25/ML-DSA-44/keygen/v1" || seed)), then run through
+ * ML-DSA.KeyGen_internal; see doc/rip-25.md. The mapping is stable and pinned
+ * by a known-answer vector, so the same seed always yields the same keypair.
  * @param[out] pubkey  Output buffer, must be PUBKEY_SIZE bytes.
  * @param[out] seckey  Output buffer, must be SECRETKEY_SIZE bytes.
  * @param[in]  seed    32-byte deterministic seed.

--- a/src/crypto/mldsa.h
+++ b/src/crypto/mldsa.h
@@ -26,7 +26,7 @@ static constexpr size_t SEED_SIZE      = 32;   // Deterministic keygen seed
 /**
  * Deterministically derive an ML-DSA-44 keypair from a 32-byte seed.
  * The seed is domain-separated and expanded to the FIPS 204 keygen seed xi
- * (xi = SHA256("AVN/RIP-25/ML-DSA-44/keygen/v1" || seed)), then run through
+ * (xi = SHA256("AVN/ML-DSA-44/keygen/v1" || seed)), then run through
  * ML-DSA.KeyGen_internal; see doc/rip-25.md. The mapping is stable and pinned
  * by a known-answer vector, so the same seed always yields the same keypair.
  * @param[out] pubkey  Output buffer, must be PUBKEY_SIZE bytes.

--- a/src/crypto/mldsa.h
+++ b/src/crypto/mldsa.h
@@ -51,22 +51,26 @@ bool KeyGenRandom(std::span<uint8_t, PUBKEY_SIZE> pubkey,
  * Sign a message with an ML-DSA-44 secret key.
  * @param[out] sig     Signature buffer, must be SIG_SIZE bytes.
  * @param[in]  msg     Message bytes.
+ * @param[in]  ctx     FIPS 204 context string (domain separation), 0..255 bytes.
  * @param[in]  seckey  Secret key, must be SECRETKEY_SIZE bytes.
  * @return true on success.
  */
 bool Sign(std::span<uint8_t, SIG_SIZE> sig,
           std::span<const uint8_t> msg,
+          std::span<const uint8_t> ctx,
           std::span<const uint8_t, SECRETKEY_SIZE> seckey);
 
 /**
  * Verify an ML-DSA-44 signature.
  * @param[in] sig     Signature, must be SIG_SIZE bytes.
  * @param[in] msg     Message bytes.
+ * @param[in] ctx     FIPS 204 context string; must match the one used to sign.
  * @param[in] pubkey  Public key, must be PUBKEY_SIZE bytes.
  * @return true if signature is valid.
  */
 bool Verify(std::span<const uint8_t, SIG_SIZE> sig,
             std::span<const uint8_t> msg,
+            std::span<const uint8_t> ctx,
             std::span<const uint8_t, PUBKEY_SIZE> pubkey);
 
 } // namespace mldsa

--- a/src/crypto/mldsa.h
+++ b/src/crypto/mldsa.h
@@ -73,6 +73,15 @@ bool Verify(std::span<const uint8_t, SIG_SIZE> sig,
             std::span<const uint8_t> ctx,
             std::span<const uint8_t, PUBKEY_SIZE> pubkey);
 
+/**
+ * @return true if this build has real ML-DSA-44 (liboqs) support; false if it
+ *         was built without liboqs, in which case KeyGen/Sign/Verify are stubs
+ *         that return false. A node built without liboqs must refuse to run as a
+ *         consensus node on any network where the RIP-25 deployment can activate,
+ *         since the stub verifier would reject every post-quantum output.
+ */
+bool IsAvailable();
+
 } // namespace mldsa
 
 #endif // BITCOIN_CRYPTO_MLDSA_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -14,6 +14,7 @@
 #include <blockfilter.h>
 #include <chain.h>
 #include <chainparams.h>
+#include <crypto/mldsa.h>
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
@@ -1215,6 +1216,18 @@ bool AppInitSanityChecks(const kernel::Context& kernel)
 
     if (!ECC_InitSanityCheck()) {
         return InitError(strprintf(_("Elliptic curve cryptography sanity check failure. %s is shutting down."), CLIENT_NAME));
+    }
+
+    // RIP-25: a node that could enforce the ML-DSA-44 (post-quantum) consensus
+    // rule MUST have liboqs compiled in. Without it, mldsa::Verify is a stub that
+    // returns false, so once the deployment activates every post-quantum output
+    // would be rejected and this node would fork from the network. Refuse to
+    // start on any chain where the deployment is not permanently disabled.
+    // (Building without liboqs requires an explicit -DWITH_LIBOQS=OFF and is only
+    // meant for tooling/dev on chains where the deployment never activates.)
+    if (!mldsa::IsAvailable() &&
+        Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MLDSA44].nStartTime != Consensus::BIP9Deployment::NEVER_ACTIVE) {
+        return InitError(_("This build has no liboqs (post-quantum) support, but the selected network can activate the ML-DSA-44 (RIP-25) soft fork. Such a node would reject every post-quantum output and fork once the deployment activates. Rebuild with liboqs enabled, or select a network where the deployment is disabled."));
     }
 
     // Probe the directory locks to give an early error message, if possible

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -10,6 +10,7 @@
 #include <coins.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
+#include <crypto/mldsa.h>
 #include <consensus/validation.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
@@ -345,6 +346,18 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
                 // 0 stack elements; this is already invalid by consensus rules
                 return false;
             }
+        }
+
+        // Check policy limits for RIP-25 ML-DSA-44 spends (witness v2, 32-byte
+        // program, not P2SH-wrapped). The witness must be exactly the canonical
+        // [signature (SIG_SIZE), pubkey (PUBKEY_SIZE)] and nothing else, matching
+        // the consensus rule, so malformed or padded v2 witnesses do not relay or
+        // bloat the mempool.
+        if (witnessversion == 2 && witnessprogram.size() == 32 && !p2sh) {
+            const auto& stack = tx.vin[i].scriptWitness.stack;
+            if (stack.size() != 2) return false;
+            if (stack[0].size() != mldsa::SIG_SIZE) return false;
+            if (stack[1].size() != mldsa::PUBKEY_SIZE) return false;
         }
     }
     return true;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -126,7 +126,7 @@ static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS{MANDATORY_SCRIPT_VERI
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION |
                                                              SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE |
-                                                             SCRIPT_VERIFY_PQ_HYBRID};
+                                                             SCRIPT_VERIFY_MLDSA44};
 
 /** For convenience, standard but not mandatory verify flags. */
 static constexpr unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS{STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};

--- a/src/pqkey.cpp
+++ b/src/pqkey.cpp
@@ -25,13 +25,15 @@ uint256 CPQPubKey::GetWitnessProgram() const
 }
 
 bool CPQPubKey::Verify(std::span<const uint8_t> sig,
-                       std::span<const uint8_t> msg) const
+                       std::span<const uint8_t> msg,
+                       std::span<const uint8_t> ctx) const
 {
     if (!m_valid) return false;
     if (sig.size() != mldsa::SIG_SIZE) return false;
     return mldsa::Verify(
         std::span<const uint8_t, mldsa::SIG_SIZE>(sig.data(), mldsa::SIG_SIZE),
         msg,
+        ctx,
         GetData());
 }
 
@@ -78,12 +80,14 @@ bool CPQKey::SetKeyData(std::span<const uint8_t, SIZE> data,
 }
 
 bool CPQKey::Sign(std::vector<uint8_t>& sig_out,
-                  std::span<const uint8_t> msg) const
+                  std::span<const uint8_t> msg,
+                  std::span<const uint8_t> ctx) const
 {
     if (!IsValid()) return false;
     sig_out.resize(mldsa::SIG_SIZE);
     return mldsa::Sign(
         std::span<uint8_t, mldsa::SIG_SIZE>(sig_out.data(), mldsa::SIG_SIZE),
         msg,
+        ctx,
         GetData());
 }

--- a/src/pqkey.h
+++ b/src/pqkey.h
@@ -59,9 +59,13 @@ public:
      * Verify an ML-DSA-44 signature over msg.
      * @param sig  Must be exactly mldsa::SIG_SIZE bytes.
      * @param msg  Message that was signed.
+     * @param ctx  FIPS 204 domain-separation context; must match signing.
+     *             Consensus spends pass GetMLDsa44DomainContext(); the default
+     *             empty context is for standalone crypto round-trips only.
      */
     bool Verify(std::span<const uint8_t> sig,
-                std::span<const uint8_t> msg) const;
+                std::span<const uint8_t> msg,
+                std::span<const uint8_t> ctx = {}) const;
 
     bool operator==(const CPQPubKey& other) const
     {
@@ -156,10 +160,14 @@ public:
      * Sign a message with this key.
      * @param sig_out  Receives the signature; resized to mldsa::SIG_SIZE.
      * @param msg      Message to sign.
+     * @param ctx      FIPS 204 domain-separation context; must match verify.
+     *                 Consensus spends pass GetMLDsa44DomainContext(); the
+     *                 default empty context is for standalone crypto only.
      * @return true on success.
      */
     bool Sign(std::vector<uint8_t>& sig_out,
-              std::span<const uint8_t> msg) const;
+              std::span<const uint8_t> msg,
+              std::span<const uint8_t> ctx = {}) const;
 
     /** Return a read-only view of the raw secret key bytes. */
     std::span<const uint8_t, SIZE> GetData() const

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -12,6 +12,7 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 
+#include <crypto/mldsa.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
@@ -422,6 +423,12 @@ void CoinControlDialog::updateLabels(CCoinControl& m_coin_control, WalletModel *
             } else if (witnessversion == 1) { // P2TR key-path spend
                 // 1 WU (witness item count) + 65 WU (Schnorr signature with len byte)
                 nBytesInputs += 66 / WITNESS_SCALE_FACTOR;
+            } else if (witnessversion == 2 && witnessprogram.size() == 32) { // RIP-25 ML-DSA-44
+                // witness = [signature (SIG_SIZE), public_key (PUBKEY_SIZE)]:
+                // 1 WU (witness item count)
+                // + 3 + SIG_SIZE WU    (signature, 3-byte compact-size length prefix)
+                // + 3 + PUBKEY_SIZE WU (public key, 3-byte compact-size length prefix)
+                nBytesInputs += (1 + (3 + mldsa::SIG_SIZE) + (3 + mldsa::PUBKEY_SIZE)) / WITNESS_SCALE_FACTOR;
             } else {
                 // not supported, should be unreachable
                 throw std::runtime_error("Trying to spend future segwit version script");

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1041,6 +1041,15 @@ public:
     bool IsSingleType() const final { return true; }
     bool ToPrivateString(const SigningProvider& arg, std::string& out) const final { return false; }
     std::optional<int64_t> ScriptSize() const override { return GetScriptForDestination(m_destination).size(); }
+    std::optional<int64_t> MaxSatisfactionWeight(bool) const override {
+        // RIP-25 native witness v2 spend: witness = [signature (SIG_SIZE),
+        // public_key (PUBKEY_SIZE)], each prefixed by a 3-byte compact-size
+        // length (both exceed 253 bytes). For segwit the satisfaction weight is
+        // the raw witness bytes (1 WU each); the witness-stack element count is
+        // added separately by the caller (MaxInputWeight).
+        return (3 + mldsa::SIG_SIZE) + (3 + mldsa::PUBKEY_SIZE);
+    }
+    std::optional<int64_t> MaxSatisfactionElems() const override { return 2; }
     std::unique_ptr<DescriptorImpl> Clone() const override
     {
         return std::make_unique<MLDsaAddressDescriptor>(m_destination);
@@ -2350,8 +2359,12 @@ public:
 
     std::optional<int64_t> MaxSatisfactionWeight(bool) const override
     {
-        constexpr int64_t WITNESS_SCALE = 4;
-        return ((mldsa::SIG_SIZE + 1) + (mldsa::PUBKEY_SIZE + 1)) * WITNESS_SCALE;
+        // Witness = [signature (SIG_SIZE), public_key (PUBKEY_SIZE)], each with a
+        // 3-byte compact-size length prefix (both exceed 253 bytes). For segwit
+        // the satisfaction weight is the raw witness bytes (1 WU each), NOT scaled
+        // by WITNESS_SCALE_FACTOR; the witness-stack element count is added by the
+        // caller (MaxInputWeight). Must match MLDsaAddressDescriptor.
+        return (3 + mldsa::SIG_SIZE) + (3 + mldsa::PUBKEY_SIZE);
     }
     std::optional<int64_t> MaxSatisfactionElems() const override { return 2; }
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -16,6 +16,23 @@
 
 typedef std::vector<unsigned char> valtype;
 
+// RIP-25 ML-DSA-44 domain-separation context. Set once at startup from
+// SelectParams() (single-threaded, before any validation) and thereafter read
+// only, so no synchronisation is needed. See interpreter.h for the rationale.
+namespace {
+std::vector<unsigned char> g_mldsa44_domain_ctx;
+} // namespace
+
+void SetMLDsa44DomainContext(std::span<const unsigned char> ctx)
+{
+    g_mldsa44_domain_ctx.assign(ctx.begin(), ctx.end());
+}
+
+std::span<const unsigned char> GetMLDsa44DomainContext()
+{
+    return g_mldsa44_domain_ctx;
+}
+
 namespace {
 
 inline bool set_success(ScriptError* ret)
@@ -2067,8 +2084,11 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
         const uint256 sighash = checker.GetMLDsa44SigHash(scriptCode);
 
         CPQPubKey pq_pubkey(std::span<const uint8_t, CPQPubKey::SIZE>(pk_bytes.data(), CPQPubKey::SIZE));
+        // Domain-separated (RIP-25): the signature must be bound to this
+        // network's ML-DSA-44 context, not merely to the sighash.
         if (!pq_pubkey.Verify(std::span<const uint8_t>(sig_bytes.data(), sig_bytes.size()),
-                              std::span<const uint8_t>(sighash.begin(), 32))) {
+                              std::span<const uint8_t>(sighash.begin(), 32),
+                              GetMLDsa44DomainContext())) {
             return set_error(serror, SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED);
         }
         return set_success(serror);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1742,9 +1742,13 @@ bool GenericTransactionSignatureChecker<T>::CheckECDSASignature(const std::vecto
 template <class T>
 uint256 GenericTransactionSignatureChecker<T>::GetMLDsa44SigHash(const CScript& scriptCode) const
 {
-    // RIP-25: Compute a BIP143-style sighash for ML-DSA-44 witness v2 inputs.
-    // SIGHASH_ALL | SIGHASH_FORKID (Avian replay protection, value 0x41).
-    constexpr int32_t nHashType = 0x41; // SIGHASH_ALL | SIGHASH_FORKID
+    // RIP-25 (normative, see doc/rip-25.md): ML-DSA-44 witness v2 inputs always
+    // commit to SIGHASH_ALL | SIGHASH_FORKID and nothing else. Unlike ECDSA and
+    // Schnorr, no sighash-type byte is carried in the witness: the signature
+    // element is the bare 2420-byte ML-DSA signature and the type is fixed here.
+    // The exact-length check in the verify branch enforces the "no carried byte"
+    // half of this rule; this constant enforces the "only this type" half.
+    constexpr int32_t nHashType = SIGHASH_ALL | SIGHASH_FORKID;
     return SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, SigVersion::WITNESS_V0, txdata);
 }
 
@@ -2043,6 +2047,8 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
         if (pk_bytes.size() != CPQPubKey::SIZE) {
             return set_error(serror, SCRIPT_ERR_PQ_PUBKEY_SIZE);
         }
+        // Exactly SIG_SIZE: the signature is the raw ML-DSA-44 signature with no
+        // trailing sighash-type byte (RIP-25 carries no hashtype in the witness).
         if (sig_bytes.size() != mldsa::SIG_SIZE) {
             return set_error(serror, SCRIPT_ERR_PQ_SIGNATURE_SIZE);
         }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2049,7 +2049,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
         // RIP-25: ML-DSA-44 post-quantum witness v2 spending rule.
         // Witness stack must be: [sig (2420 bytes), pubkey (1312 bytes)]
         // Witness program is SHA256(pubkey).
-        if (!(flags & SCRIPT_VERIFY_PQ_HYBRID)) {
+        if (!(flags & SCRIPT_VERIFY_MLDSA44)) {
             if (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM) {
                 return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM);
             }
@@ -2228,7 +2228,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     return set_success(serror);
 }
 
-size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& witprogram, const CScriptWitness& witness)
+size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& witprogram, const CScriptWitness& witness, unsigned int flags)
 {
     if (witversion == 0) {
         if (witprogram.size() == WITNESS_V0_KEYHASH_SIZE)
@@ -2238,6 +2238,15 @@ size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& wi
             CScript subscript(witness.stack.back().begin(), witness.stack.back().end());
             return subscript.GetSigOpCount(true);
         }
+    }
+
+    // RIP-25: an ML-DSA-44 spend (witness v2, 32-byte program) performs exactly
+    // one signature verification. Charge it a sigop cost so it counts against
+    // the block and per-tx sigop limits and the sigop-based fee weighting, but
+    // only once the post-quantum rule is active (the same gate as the
+    // verification itself), so pre-activation cost accounting is unchanged.
+    if (witversion == 2 && witprogram.size() == 32 && (flags & SCRIPT_VERIFY_MLDSA44)) {
+        return MLDSA44_SIGOP_COST;
     }
 
     // Future flags may be implemented here.
@@ -2256,7 +2265,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
     int witnessversion;
     std::vector<unsigned char> witnessprogram;
     if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
-        return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty);
+        return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty, flags);
     }
 
     if (scriptPubKey.IsPayToScriptHash() && scriptSig.IsPushOnly()) {
@@ -2268,7 +2277,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
         }
         CScript subscript(data.begin(), data.end());
         if (subscript.IsWitnessProgram(witnessversion, witnessprogram)) {
-            return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty);
+            return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty, flags);
         }
     }
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -273,6 +273,23 @@ public:
 template <class T>
 uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int32_t nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr, SigHashCache* sighash_cache = nullptr);
 
+/**
+ * RIP-25 ML-DSA-44 domain-separation context (see doc/rip-25.md).
+ *
+ * The context is bound into every ML-DSA-44 signature via FIPS 204's context
+ * string, so a signature is valid only for the RIP-25 scheme on the network it
+ * was made for. It is set once from the active network in SelectParams() and
+ * read by both the consensus verifier (this library) and the signer. This
+ * lives in bitcoin_consensus because the verifier cannot depend on chainparams;
+ * the higher layer that owns the network selection pushes the value in.
+ *
+ * Must be set before any script validation. If left unset the context is empty,
+ * which is self-consistent (signer and verifier agree) but provides no
+ * separation; production and tests both set it through SelectParams().
+ */
+void SetMLDsa44DomainContext(std::span<const unsigned char> ctx);
+std::span<const unsigned char> GetMLDsa44DomainContext();
+
 class BaseSignatureChecker
 {
 public:

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -149,7 +149,7 @@ enum : uint32_t {
     SCRIPT_ENABLE_SIGHASH_FORKID = (1U << 21),
 
     // RIP-25: Enforce ML-DSA-44 post-quantum signing rules for witness v2 outputs.
-    SCRIPT_VERIFY_PQ_HYBRID = (1U << 22),
+    SCRIPT_VERIFY_MLDSA44 = (1U << 22),
 
     // AIP-0009: allow push data up to MAX_SCRIPT_ELEMENT_SIZE_ANS_V2 after DEPLOYMENT_ANS_V2.
     SCRIPT_VERIFY_ANS_V2 = (1U << 23),

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -66,6 +66,18 @@ static constexpr int64_t VALIDATION_WEIGHT_PER_SIGOP_PASSED{50};
 // How much weight budget is added to the witness size (Tapscript only, see BIP 342).
 static constexpr int64_t VALIDATION_WEIGHT_OFFSET{50};
 
+// RIP-25: sigop cost charged for one ML-DSA-44 (witness v2) signature
+// verification. Counted only once the post-quantum deployment is active, so it
+// flows through the existing block sigop limit (MAX_BLOCK_SIGOPS_COST), the
+// per-transaction policy cap (MAX_STANDARD_TX_SIGOPS_COST), and the sigop-based
+// fee weighting (DEFAULT_BYTES_PER_SIGOP) without a parallel accounting system.
+// The measured verify is ~16.5us (cheaper than an ECDSA verify), and the
+// ~3.7 KB witness already bounds the count by weight; 50 matches the Tapscript
+// per-checksig cost and gives a conservative explicit ceiling of
+// MAX_BLOCK_SIGOPS_COST/50 = 1600 PQ verifications per block and
+// MAX_STANDARD_TX_SIGOPS_COST/50 = 320 per standard transaction.
+static constexpr int64_t MLDSA44_SIGOP_COST{50};
+
 template <typename T>
 std::vector<unsigned char> ToByteVector(const T& in)
 {

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -520,12 +520,13 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
         return SignTaproot(provider, creator, WitnessV1Taproot(XOnlyPubKey{vSolutions[0]}), sigdata, ret);
 
     case TxoutType::WITNESS_V2_MLDSA44: {
-        // vSolutions[0] is the 32-byte witness program = SHA256(mldsa_pubkey)
+        // vSolutions[0] is the 32-byte witness program = SHA256(mldsa_pubkey).
+        // CreateMLDsa44Sig is virtual: the real creator produces a genuine
+        // signature, the dummy creator produces a correctly-sized placeholder
+        // (for fee estimation), and other creators default to unsupported.
         uint256 program(vSolutions[0]);
-        const auto* mtxcreator = dynamic_cast<const MutableTransactionSignatureCreator*>(&creator);
-        if (!mtxcreator) return false;
         std::vector<unsigned char> sig, pubkey;
-        if (!mtxcreator->CreateMLDsa44Sig(provider, sig, pubkey, program)) return false;
+        if (!creator.CreateMLDsa44Sig(provider, sig, pubkey, program)) return false;
         // Witness stack: [sig, pubkey] (sig pushed first so it's item 0 at stack top after pubkey)
         ret.push_back(std::move(sig));
         ret.push_back(std::move(pubkey));
@@ -797,6 +798,13 @@ public:
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* tweak, SigVersion sigversion) const override
     {
         sig.assign(64, '\000');
+        return true;
+    }
+    bool CreateMLDsa44Sig(const SigningProvider& provider, std::vector<unsigned char>& sig_out, std::vector<unsigned char>& pubkey_out, const uint256& program) const override
+    {
+        // RIP-25: dummy witness of the exact spend sizes for fee estimation.
+        sig_out.assign(mldsa::SIG_SIZE, '\000');
+        pubkey_out.assign(mldsa::PUBKEY_SIZE, '\000');
         return true;
     }
 };

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -113,8 +113,11 @@ bool MutableTransactionSignatureCreator::CreateMLDsa44Sig(const SigningProvider&
     uint256 sighash = SignatureHash(scriptCode, m_txto, nIn, nHashType, amount, SigVersion::WITNESS_V0, m_txdata);
 
     sig_out.resize(mldsa::SIG_SIZE);
+    // Bind to this network's RIP-25 ML-DSA-44 context; must match the verifier
+    // (VerifyWitnessProgram), which uses the same GetMLDsa44DomainContext().
     if (!pq_key.Sign(sig_out,
-                     std::span<const uint8_t>(sighash.begin(), 32))) {
+                     std::span<const uint8_t>(sighash.begin(), 32),
+                     GetMLDsa44DomainContext())) {
         return false;
     }
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -106,7 +106,10 @@ bool MutableTransactionSignatureCreator::CreateMLDsa44Sig(const SigningProvider&
     CScript scriptCode;
     scriptCode << OP_2 << std::vector<unsigned char>(program.begin(), program.end());
 
-    constexpr int32_t nHashType = 0x41; // SIGHASH_ALL | SIGHASH_FORKID
+    // RIP-25 (normative): sign SIGHASH_ALL | SIGHASH_FORKID only, and emit the bare
+    // 2420-byte ML-DSA signature with no appended sighash-type byte. Must stay in
+    // lockstep with GenericTransactionSignatureChecker::GetMLDsa44SigHash.
+    constexpr int32_t nHashType = SIGHASH_ALL | SIGHASH_FORKID;
     uint256 sighash = SignatureHash(scriptCode, m_txto, nIn, nHashType, amount, SigVersion::WITNESS_V0, m_txdata);
 
     sig_out.resize(mldsa::SIG_SIZE);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -34,6 +34,10 @@ public:
     /** Create a singular (non-script) signature. */
     virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
     virtual bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const =0;
+    /** RIP-25: Create an ML-DSA-44 witness (signature + public key) for the given
+     *  32-byte witness program. Default: not supported (e.g. non-transaction
+     *  creators). Overridden by the real and dummy transaction creators. */
+    virtual bool CreateMLDsa44Sig(const SigningProvider& provider, std::vector<unsigned char>& sig_out, std::vector<unsigned char>& pubkey_out, const uint256& program) const { return false; }
 };
 
 /** A signature creator for transactions. */
@@ -53,7 +57,7 @@ public:
     bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CreateSchnorrSig(const SigningProvider& provider, std::vector<unsigned char>& sig, const XOnlyPubKey& pubkey, const uint256* leaf_hash, const uint256* merkle_root, SigVersion sigversion) const override;
     /** RIP-25: Create an ML-DSA-44 signature over sighash(scriptCode). Returns {sig, pubkey}. */
-    bool CreateMLDsa44Sig(const SigningProvider& provider, std::vector<unsigned char>& sig_out, std::vector<unsigned char>& pubkey_out, const uint256& program) const;
+    bool CreateMLDsa44Sig(const SigningProvider& provider, std::vector<unsigned char>& sig_out, std::vector<unsigned char>& pubkey_out, const uint256& program) const override;
 };
 
 /** A signature checker that accepts all signatures */

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -374,6 +374,22 @@ bool MultiSigningProvider::GetTaprootBuilder(const XOnlyPubKey& output_key, Tapr
     return false;
 }
 
+bool MultiSigningProvider::GetPQKey(const uint256& program, CPQKey& key) const
+{
+    for (const auto& provider: m_providers) {
+        if (provider->GetPQKey(program, key)) return true;
+    }
+    return false;
+}
+
+bool MultiSigningProvider::HavePQKey(const uint256& program) const
+{
+    for (const auto& provider: m_providers) {
+        if (provider->HavePQKey(program)) return true;
+    }
+    return false;
+}
+
 /*static*/ TaprootBuilder::NodeInfo TaprootBuilder::Combine(NodeInfo&& a, NodeInfo&& b)
 {
     NodeInfo ret;

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -344,6 +344,8 @@ public:
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
+    bool GetPQKey(const uint256& program, CPQKey& key) const override;
+    bool HavePQKey(const uint256& program) const override;
 };
 
 #endif // BITCOIN_SCRIPT_SIGNINGPROVIDER_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(test_bitcoin
   key_io_tests.cpp
   key_tests.cpp
   pqkey_tests.cpp
+  mldsa44_sighash_tests.cpp
   logging_tests.cpp
   mempool_tests.cpp
   merkle_tests.cpp

--- a/src/test/mldsa44_sighash_tests.cpp
+++ b/src/test/mldsa44_sighash_tests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(sighash_policy_is_fixed_and_carries_no_type_byte)
     const CScript scriptCode = CScript() << OP_2 << program_bytes;
     const CMutableTransaction txSpend = BuildSpendingTransaction(CScript(), CScriptWitness(), txCredit);
 
-    const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_PQ_HYBRID;
+    const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_MLDSA44;
 
     // Run the real consensus verifier with an arbitrary witness stack. The BIP143
     // sighash does not depend on the witness, so a checker built from any spend of
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(domain_separation_binds_the_network)
                                           SIGHASH_ALL | SIGHASH_FORKID, amount,
                                           SigVersion::WITNESS_V0);
 
-    const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_PQ_HYBRID;
+    const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_MLDSA44;
     auto verify = [&](const std::vector<uint8_t>& sig, ScriptError& err) {
         CScriptWitness wit;
         wit.stack.push_back(sig);
@@ -176,6 +176,26 @@ BOOST_AUTO_TEST_CASE(domain_separation_binds_the_network)
     err = SCRIPT_ERR_OK;
     BOOST_CHECK(verify(sig_ok, err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+}
+
+BOOST_AUTO_TEST_CASE(pq_verify_sigop_cost_gated_on_activation)
+{
+    // A witness-v2 (ML-DSA-44) spend counts MLDSA44_SIGOP_COST sigops once the PQ
+    // rule is active, and 0 before it, so pre-activation cost accounting is
+    // unchanged while active blocks/txs are bounded by the existing sigop limits.
+    // Shape-based (no real verify), so it runs with or without liboqs.
+    std::vector<unsigned char> program(32, 0xAB);
+    const CScript spk = CScript() << OP_2 << program;
+    CScriptWitness wit;
+    wit.stack.emplace_back(mldsa::SIG_SIZE, 0x11);
+    wit.stack.emplace_back(mldsa::PUBKEY_SIZE, 0x22);
+
+    const unsigned int base = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH;
+    // Pre-activation: witness v2 still contributes nothing.
+    BOOST_CHECK_EQUAL(CountWitnessSigOps(CScript(), spk, &wit, base), 0U);
+    // Active: one PQ verify is charged the fixed sigop cost.
+    BOOST_CHECK_EQUAL(CountWitnessSigOps(CScript(), spk, &wit, base | SCRIPT_VERIFY_MLDSA44),
+                      static_cast<size_t>(MLDSA44_SIGOP_COST));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mldsa44_sighash_tests.cpp
+++ b/src/test/mldsa44_sighash_tests.cpp
@@ -81,7 +81,8 @@ BOOST_AUTO_TEST_CASE(sighash_policy_is_fixed_and_carries_no_type_byte)
                                           SIGHASH_ALL | SIGHASH_FORKID, amount,
                                           SigVersion::WITNESS_V0);
     std::vector<uint8_t> sig;
-    BOOST_REQUIRE(key.Sign(sig, std::span<const uint8_t>(sighash.begin(), 32)));
+    BOOST_REQUIRE(key.Sign(sig, std::span<const uint8_t>(sighash.begin(), 32),
+                           GetMLDsa44DomainContext()));
     // The signer emits the raw signature with no appended hashtype byte.
     BOOST_REQUIRE_EQUAL(sig.size(), mldsa::SIG_SIZE);
 
@@ -106,11 +107,75 @@ BOOST_AUTO_TEST_CASE(sighash_policy_is_fixed_and_carries_no_type_byte)
                                                     SigVersion::WITNESS_V0);
     BOOST_REQUIRE(sighash_no_forkid != sighash);
     std::vector<uint8_t> sig_wrong_type;
-    BOOST_REQUIRE(key.Sign(sig_wrong_type, std::span<const uint8_t>(sighash_no_forkid.begin(), 32)));
+    BOOST_REQUIRE(key.Sign(sig_wrong_type, std::span<const uint8_t>(sighash_no_forkid.begin(), 32),
+                           GetMLDsa44DomainContext()));
     BOOST_REQUIRE_EQUAL(sig_wrong_type.size(), mldsa::SIG_SIZE);
     err = SCRIPT_ERR_OK;
     BOOST_CHECK(!verify(sig_wrong_type, pk_bytes, err));
     BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED);
+}
+
+BOOST_AUTO_TEST_CASE(domain_separation_binds_the_network)
+{
+    // A signature made under a different ML-DSA-44 context (another network's,
+    // or none) must not verify under this node's context, even though the
+    // sighash, program, and key are identical.
+    std::array<uint8_t, mldsa::SEED_SIZE> seed{};
+    for (size_t i = 0; i < seed.size(); ++i) seed[i] = static_cast<uint8_t>(0x80 + i);
+
+    CPQKey key;
+    if (!key.SetSeed(std::span<const uint8_t, mldsa::SEED_SIZE>(seed))) {
+        BOOST_WARN_MESSAGE(false, "liboqs unavailable; skipping ML-DSA-44 domain separation test");
+        return;
+    }
+    const CPQPubKey pub = key.GetPubKey();
+    const uint256 program = pub.GetWitnessProgram();
+    const std::vector<uint8_t> program_bytes(program.begin(), program.end());
+    const std::vector<uint8_t> pk_bytes(pub.GetData().begin(), pub.GetData().end());
+
+    const CScript spk = CScript() << OP_2 << program_bytes;
+    const CAmount amount = 100'000'000;
+    const CTransaction txCredit{BuildCreditingTransaction(spk, amount)};
+    const CScript scriptCode = CScript() << OP_2 << program_bytes;
+    const CMutableTransaction txSpend = BuildSpendingTransaction(CScript(), CScriptWitness(), txCredit);
+    const uint256 sighash = SignatureHash(scriptCode, txSpend, 0,
+                                          SIGHASH_ALL | SIGHASH_FORKID, amount,
+                                          SigVersion::WITNESS_V0);
+
+    const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_PQ_HYBRID;
+    auto verify = [&](const std::vector<uint8_t>& sig, ScriptError& err) {
+        CScriptWitness wit;
+        wit.stack.push_back(sig);
+        wit.stack.push_back(pk_bytes);
+        const CMutableTransaction spend = BuildSpendingTransaction(CScript(), wit, txCredit);
+        const CTransaction tx(spend);
+        return VerifyScript(CScript(), spk, &tx.vin[0].scriptWitness, flags,
+                            TransactionSignatureChecker(&tx, 0, amount, MissingDataBehavior::ASSERT_FAIL),
+                            &err);
+    };
+
+    // The active context must be non-empty (SelectParams set it in the fixture),
+    // otherwise this test would not be exercising separation at all.
+    const auto node_ctx = GetMLDsa44DomainContext();
+    BOOST_REQUIRE(!node_ctx.empty());
+
+    // Sign under a foreign context (one byte flipped) instead of the node's.
+    std::vector<unsigned char> foreign_ctx(node_ctx.begin(), node_ctx.end());
+    foreign_ctx.back() ^= 0x01;
+    std::vector<uint8_t> sig_foreign;
+    BOOST_REQUIRE(key.Sign(sig_foreign, std::span<const uint8_t>(sighash.begin(), 32),
+                           std::span<const uint8_t>(foreign_ctx)));
+    ScriptError err = SCRIPT_ERR_OK;
+    BOOST_CHECK(!verify(sig_foreign, err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED);
+
+    // Signing under the node's real context DOES verify: proves the failure
+    // above is the context binding, not something else.
+    std::vector<uint8_t> sig_ok;
+    BOOST_REQUIRE(key.Sign(sig_ok, std::span<const uint8_t>(sighash.begin(), 32), node_ctx));
+    err = SCRIPT_ERR_OK;
+    BOOST_CHECK(verify(sig_ok, err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mldsa44_sighash_tests.cpp
+++ b/src/test/mldsa44_sighash_tests.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2024-present The Avian Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+// RIP-25: locks the ML-DSA-44 (witness v2) sighash policy.
+//
+// The rule (doc/rip-25.md) is: every ML-DSA-44 spend commits to exactly
+// SIGHASH_ALL | SIGHASH_FORKID, and the witness carries NO sighash-type byte --
+// the signature element is the bare 2420-byte ML-DSA signature. These tests
+// exercise the real consensus verifier (VerifyScript) to prove both halves:
+//   1. a correctly signed spend verifies;
+//   2. appending any sighash-type byte makes the signature the wrong length and
+//      is rejected (SCRIPT_ERR_PQ_SIGNATURE_SIZE);
+//   3. a signature over a digest built with any other hashtype (e.g. plain
+//      SIGHASH_ALL, no FORKID) is rejected (SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED).
+
+#include <crypto/mldsa.h>
+#include <pqkey.h>
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <script/script.h>
+#include <script/script_error.h>
+#include <test/util/transaction_utils.h>
+#include <uint256.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(mldsa44_sighash_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(sighash_policy_is_fixed_and_carries_no_type_byte)
+{
+    // Deterministic ML-DSA-44 key from a fixed seed.
+    std::array<uint8_t, mldsa::SEED_SIZE> seed{};
+    for (size_t i = 0; i < seed.size(); ++i) seed[i] = static_cast<uint8_t>(i);
+
+    CPQKey key;
+    if (!key.SetSeed(std::span<const uint8_t, mldsa::SEED_SIZE>(seed))) {
+        // Built without liboqs: the post-quantum path is a stub. Nothing to lock.
+        BOOST_WARN_MESSAGE(false, "liboqs unavailable; skipping ML-DSA-44 sighash policy test");
+        return;
+    }
+    const CPQPubKey pub = key.GetPubKey();
+    const uint256 program = pub.GetWitnessProgram();
+    const std::vector<uint8_t> program_bytes(program.begin(), program.end());
+    const std::vector<uint8_t> pk_bytes(pub.GetData().begin(), pub.GetData().end());
+
+    // Native witness v2 output: OP_2 <32-byte SHA256(pubkey)>.
+    const CScript spk = CScript() << OP_2 << program_bytes;
+    const CAmount amount = 100'000'000;
+    const CTransaction txCredit{BuildCreditingTransaction(spk, amount)};
+
+    // scriptCode used for the sighash, identical to both signer and verifier.
+    const CScript scriptCode = CScript() << OP_2 << program_bytes;
+    const CMutableTransaction txSpend = BuildSpendingTransaction(CScript(), CScriptWitness(), txCredit);
+
+    const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_PQ_HYBRID;
+
+    // Run the real consensus verifier with an arbitrary witness stack. The BIP143
+    // sighash does not depend on the witness, so a checker built from any spend of
+    // this credit is correct for every case below.
+    auto verify = [&](const std::vector<uint8_t>& sig, const std::vector<uint8_t>& pk, ScriptError& err) {
+        CScriptWitness wit;
+        wit.stack.push_back(sig);  // stack[0] = signature
+        wit.stack.push_back(pk);   // stack[1] = public key
+        const CMutableTransaction spend = BuildSpendingTransaction(CScript(), wit, txCredit);
+        const CTransaction tx(spend);
+        return VerifyScript(CScript(), spk, &tx.vin[0].scriptWitness, flags,
+                            TransactionSignatureChecker(&tx, 0, amount, MissingDataBehavior::ASSERT_FAIL),
+                            &err);
+    };
+
+    // (1) Canonical spend: sign SIGHASH_ALL|SIGHASH_FORKID, bare 2420-byte sig.
+    const uint256 sighash = SignatureHash(scriptCode, txSpend, 0,
+                                          SIGHASH_ALL | SIGHASH_FORKID, amount,
+                                          SigVersion::WITNESS_V0);
+    std::vector<uint8_t> sig;
+    BOOST_REQUIRE(key.Sign(sig, std::span<const uint8_t>(sighash.begin(), 32)));
+    // The signer emits the raw signature with no appended hashtype byte.
+    BOOST_REQUIRE_EQUAL(sig.size(), mldsa::SIG_SIZE);
+
+    ScriptError err = SCRIPT_ERR_OK;
+    BOOST_CHECK(verify(sig, pk_bytes, err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    // (2) Any carried sighash-type byte makes the element the wrong length.
+    for (uint8_t type_byte : {uint8_t{0x41}, uint8_t{0x01}, uint8_t{0x00}}) {
+        std::vector<uint8_t> sig_with_byte = sig;
+        sig_with_byte.push_back(type_byte);
+        err = SCRIPT_ERR_OK;
+        BOOST_CHECK(!verify(sig_with_byte, pk_bytes, err));
+        BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PQ_SIGNATURE_SIZE);
+    }
+
+    // (3) A signature over a different hashtype's digest must not verify: the
+    // verifier commits to SIGHASH_ALL|SIGHASH_FORKID only. Here we sign the
+    // SIGHASH_ALL (no FORKID) digest but present a correctly-sized 2420-byte sig.
+    const uint256 sighash_no_forkid = SignatureHash(scriptCode, txSpend, 0,
+                                                    SIGHASH_ALL, amount,
+                                                    SigVersion::WITNESS_V0);
+    BOOST_REQUIRE(sighash_no_forkid != sighash);
+    std::vector<uint8_t> sig_wrong_type;
+    BOOST_REQUIRE(key.Sign(sig_wrong_type, std::span<const uint8_t>(sighash_no_forkid.begin(), 32)));
+    BOOST_REQUIRE_EQUAL(sig_wrong_type.size(), mldsa::SIG_SIZE);
+    err = SCRIPT_ERR_OK;
+    BOOST_CHECK(!verify(sig_wrong_type, pk_bytes, err));
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_PQ_SIGNATURE_VERIFY_FAILED);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pqkey_tests.cpp
+++ b/src/test/pqkey_tests.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(deterministic_keygen_from_seed)
 BOOST_AUTO_TEST_CASE(derivation_known_answer_vector)
 {
     // RIP-25 key-derivation known-answer vector.  This pins the exact mapping
-    //   seed -> xi = SHA256("AVN/RIP-25/ML-DSA-44/keygen/v1" || seed)
+    //   seed -> xi = SHA256("AVN/ML-DSA-44/keygen/v1" || seed)
     //        -> (pk, sk) = ML-DSA.KeyGen_internal(xi)
     // so the derivation can never silently drift (liboqs upgrade, struct-ABI
     // change, DST change, or expansion change all break these values).  If this
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(derivation_known_answer_vector)
     // Witness program is SHA256(pubkey); this is the on-chain commitment.
     const uint256 wp = key.GetPubKey().GetWitnessProgram();
     BOOST_CHECK_EQUAL(HexStr(wp),
-        "e7fb04e58cb66a825e9f045ea60e6a6d72bbefddb93343321bc64cd03c4265b2");
+        "a7da36522f995f7a2ccba0e8d10f6b7d2dcd7882486a38462176ba720823a0fb");
 
     // Sanity: the witness program equals SHA256 over the raw public key bytes.
     auto pk = key.GetPubKey().GetData();
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(derivation_known_answer_vector)
     uint256 skh;
     CSHA256().Write(sk.data(), sk.size()).Finalize(skh.begin());
     BOOST_CHECK_EQUAL(HexStr(skh),
-        "5e6259e974035d534b5007ee56b08beaf8d91a31d593cb786c8eede792e1b1c8");
+        "f59fd75b78cb6727f9c626dc82898ce6b5f8794418708330e686a1e1a5fc4099");
 
     // And the derived keypair must be internally consistent: a signature made
     // with sk verifies under pk.  This proves the packed sk matches the pk.

--- a/src/test/pqkey_tests.cpp
+++ b/src/test/pqkey_tests.cpp
@@ -7,8 +7,10 @@
 // Ported from Ravencoin RIP-25 <https://github.com/RavenProject/Ravencoin/pull/1281>
 
 #include <crypto/mldsa.h>
+#include <crypto/sha256.h>
 #include <pqkey.h>
 #include <uint256.h>
+#include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -56,6 +58,51 @@ BOOST_AUTO_TEST_CASE(deterministic_keygen_from_seed)
     BOOST_CHECK(key1.GetPubKey() == key2.GetPubKey());
     // Same seed → same witness program
     BOOST_CHECK(key1.GetPubKey().GetWitnessProgram() == key2.GetPubKey().GetWitnessProgram());
+}
+
+BOOST_AUTO_TEST_CASE(derivation_known_answer_vector)
+{
+    // RIP-25 key-derivation known-answer vector.  This pins the exact mapping
+    //   seed -> xi = SHA256("AVN/RIP-25/ML-DSA-44/keygen/v1" || seed)
+    //        -> (pk, sk) = ML-DSA.KeyGen_internal(xi)
+    // so the derivation can never silently drift (liboqs upgrade, struct-ABI
+    // change, DST change, or expansion change all break these values).  If this
+    // test fails after a dependency bump, the derivation changed and every
+    // previously derived PQ address/key would move: treat it as a consensus /
+    // wallet-recovery event, not a value to blindly update.
+    //
+    // Seed = 0x00,0x01,...,0x1f.
+    std::array<uint8_t, mldsa::SEED_SIZE> seed{};
+    for (size_t i = 0; i < seed.size(); ++i) seed[i] = static_cast<uint8_t>(i);
+
+    CPQKey key;
+    BOOST_REQUIRE(key.SetSeed(std::span<const uint8_t, mldsa::SEED_SIZE>(seed)));
+
+    // Witness program is SHA256(pubkey); this is the on-chain commitment.
+    const uint256 wp = key.GetPubKey().GetWitnessProgram();
+    BOOST_CHECK_EQUAL(HexStr(wp),
+        "e7fb04e58cb66a825e9f045ea60e6a6d72bbefddb93343321bc64cd03c4265b2");
+
+    // Sanity: the witness program equals SHA256 over the raw public key bytes.
+    auto pk = key.GetPubKey().GetData();
+    uint256 pkh;
+    CSHA256().Write(pk.data(), pk.size()).Finalize(pkh.begin());
+    BOOST_CHECK_EQUAL(HexStr(pkh), HexStr(wp));
+
+    // Pin the secret key too (SHA256 of the 2560-byte packed sk).
+    auto sk = key.GetData();
+    uint256 skh;
+    CSHA256().Write(sk.data(), sk.size()).Finalize(skh.begin());
+    BOOST_CHECK_EQUAL(HexStr(skh),
+        "5e6259e974035d534b5007ee56b08beaf8d91a31d593cb786c8eede792e1b1c8");
+
+    // And the derived keypair must be internally consistent: a signature made
+    // with sk verifies under pk.  This proves the packed sk matches the pk.
+    std::array<uint8_t, 32> msg{};
+    for (size_t i = 0; i < msg.size(); ++i) msg[i] = static_cast<uint8_t>(0x40 + i);
+    std::vector<uint8_t> sig;
+    BOOST_REQUIRE(key.Sign(sig, std::span<const uint8_t>(msg)));
+    BOOST_CHECK(key.GetPubKey().Verify(std::span<const uint8_t>(sig), std::span<const uint8_t>(msg)));
 }
 
 BOOST_AUTO_TEST_CASE(sign_and_verify)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -74,7 +74,7 @@ static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("DISCOURAGE_OP_SUCCESS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS},
     {std::string("DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION},
     {std::string("SIGHASH_FORKID"), (unsigned int)SCRIPT_ENABLE_SIGHASH_FORKID},
-    {std::string("PQ_HYBRID"), (unsigned int)SCRIPT_VERIFY_PQ_HYBRID},
+    {std::string("MLDSA44"), (unsigned int)SCRIPT_VERIFY_MLDSA44},
     {std::string("ANS_V2"), (unsigned int)SCRIPT_VERIFY_ANS_V2},
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2664,7 +2664,7 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
 
     // RIP-25: Enforce ML-DSA-44 post-quantum signing rules after DEPLOYMENT_MLDSA44 activation
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_MLDSA44)) {
-        flags |= SCRIPT_VERIFY_PQ_HYBRID;
+        flags |= SCRIPT_VERIFY_MLDSA44;
     }
 
     if (DeploymentActiveAt(block_index, chainman, Consensus::DEPLOYMENT_ANS_V2)) {

--- a/test/functional/feature_mldsa44.py
+++ b/test/functional/feature_mldsa44.py
@@ -12,7 +12,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
-    assert_raises_rpc_error,
 )
 
 # RIP-25 ML-DSA-44 witness element sizes (bytes).

--- a/test/functional/feature_mldsa44.py
+++ b/test/functional/feature_mldsa44.py
@@ -11,7 +11,13 @@ any activation block logic.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than_or_equal,
+    assert_raises_rpc_error,
 )
+
+# RIP-25 ML-DSA-44 witness element sizes (bytes).
+MLDSA44_SIG_SIZE = 2420
+MLDSA44_PUBKEY_SIZE = 1312
 
 
 class MLDsa44Test(BitcoinTestFramework):
@@ -21,6 +27,22 @@ class MLDsa44Test(BitcoinTestFramework):
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
+
+    def assert_pq_witness(self, node, txid, pq_prevouts):
+        """Every input in txid that spends a prevout in pq_prevouts must carry
+        exactly the RIP-25 witness: [signature (2420 bytes), pubkey (1312 bytes)].
+        Uses the wallet's own tx hex so it works without -txindex."""
+        decoded = node.decoderawtransaction(node.gettransaction(txid)["hex"])
+        seen = set()
+        for vin in decoded["vin"]:
+            key = (vin["txid"], vin["vout"])
+            if key in pq_prevouts:
+                wit = vin.get("txinwitness", [])
+                assert_equal(len(wit), 2)
+                assert_equal(len(wit[0]) // 2, MLDSA44_SIG_SIZE)     # ML-DSA-44 signature
+                assert_equal(len(wit[1]) // 2, MLDSA44_PUBKEY_SIZE)  # ML-DSA-44 public key
+                seen.add(key)
+        assert_equal(seen, pq_prevouts)
 
     def run_test(self):
         node = self.nodes[0]
@@ -71,6 +93,70 @@ class MLDsa44Test(BitcoinTestFramework):
         info3 = node.getaddressinfo(pq_addr)
         assert_equal(info3["ispostquantum"], True)
         assert_equal(info3["ismine"], True)
+
+        legacy_dest = node.getnewaddress("", "legacy")
+
+        self.log.info("Test spending FROM a PQ address (single ML-DSA-44 input)")
+
+        # Fund a dedicated PQ address, then spend exactly that UTXO (add_inputs
+        # False so only the ML-DSA input is used) to a legacy destination.
+        spend_addr = node.getnewaddress("", "pq")
+        node.sendtoaddress(spend_addr, 10.0)
+        self.generate(node, 1)
+        utxo = node.listunspent(1, 9999999, [spend_addr])[0]
+
+        res = node.send(
+            outputs={legacy_dest: 9.0},
+            options={"inputs": [{"txid": utxo["txid"], "vout": utxo["vout"]}],
+                     "add_inputs": False, "change_type": "legacy"})
+        assert_equal(res["complete"], True)
+        self.generate(node, 1)
+
+        # Confirmed in a block => consensus verified and accepted the ML-DSA spend
+        # (verify_with_ctx_str + domain context + witness/program/sigop rules).
+        assert_greater_than_or_equal(node.gettransaction(res["txid"])["confirmations"], 1)
+        self.assert_pq_witness(node, res["txid"], {(utxo["txid"], utxo["vout"])})
+
+        self.log.info("Test two PQ inputs + a PQ output in one transaction")
+
+        # Two PQ inputs, spent together, paying a legacy address and a PQ address
+        # (a PQ output created by a normal, non-coinbase transaction).
+        a = node.getnewaddress("", "pq")
+        b = node.getnewaddress("", "pq")
+        node.sendtoaddress(a, 5.0)
+        node.sendtoaddress(b, 5.0)
+        self.generate(node, 1)
+        ua = node.listunspent(1, 9999999, [a])[0]
+        ub = node.listunspent(1, 9999999, [b])[0]
+
+        pq_out = node.getnewaddress("", "pq")
+        res2 = node.send(
+            outputs={legacy_dest: 6.0, pq_out: 3.0},
+            options={"inputs": [{"txid": ua["txid"], "vout": ua["vout"]},
+                                {"txid": ub["txid"], "vout": ub["vout"]}],
+                     "add_inputs": False, "change_type": "legacy"})
+        assert_equal(res2["complete"], True)
+        self.generate(node, 1)
+
+        assert_greater_than_or_equal(node.gettransaction(res2["txid"])["confirmations"], 1)
+        # Both PQ inputs carry the canonical witness.
+        self.assert_pq_witness(node, res2["txid"],
+                               {(ua["txid"], ua["vout"]), (ub["txid"], ub["vout"])})
+        # The PQ output was created and is owned/spendable by the wallet.
+        pq_created = node.listunspent(1, 9999999, [pq_out])
+        assert_equal(len(pq_created), 1)
+
+        self.log.info("Test spending a non-coinbase PQ output (closes the loop)")
+
+        uc = pq_created[0]
+        res3 = node.send(
+            outputs={legacy_dest: 2.0},
+            options={"inputs": [{"txid": uc["txid"], "vout": uc["vout"]}],
+                     "add_inputs": False, "change_type": "legacy"})
+        assert_equal(res3["complete"], True)
+        self.generate(node, 1)
+        assert_greater_than_or_equal(node.gettransaction(res3["txid"])["confirmations"], 1)
+        self.assert_pq_witness(node, res3["txid"], {(uc["txid"], uc["vout"])})
 
         self.log.info("Test that 'pq' address type is rejected on non-regtest without deployment")
         # On regtest DEPLOYMENT_MLDSA44 is always active, so no negative-activation


### PR DESCRIPTION
## Summary

Implements **RIP-25**: ML-DSA-44 (FIPS-204) post-quantum signatures for Avian, delivered as a SegWit **witness v2** output type (`avn1p…` bech32m addresses, `mldsa44()` descriptor). This is the Phase-0 consensus-hardening work that makes the existing ML-DSA proof-of-concept safe to eventually activate.

**Activation is deliberately gated and safe to merge now:** `DEPLOYMENT_MLDSA44` is **`NEVER_ACTIVE` on mainnet** and `ALWAYS_ACTIVE` on testnet/regtest. Merging ships activation-capable code without changing mainnet consensus. Existing ECDSA outputs are unaffected.

The design is written up in [`doc/rip-25.md`](doc/rip-25.md).

## Phase-0 consensus hardening (all five open items resolved)

1. **Key derivation** — replaced the liboqs-RNG-hijack keygen with a seeded **FIPS-204 KeyGen**, pinned by a KAT. `xi = SHA256("AVN/ML-DSA-44/keygen/v1" || leaf)`.
2. **Domain separation** — non-empty FIPS-204 context `"AVN/ML-DSA-44/v1/" || genesis-hash`, set per-network in `SelectParams`, so signatures can't replay across networks.
3. **DoS / cost accounting** — `MLDSA44_SIGOP_COST=50` gated on `SCRIPT_VERIFY_MLDSA44`, plus a witness-v2 branch in `IsWitnessStandard`. Verify benchmarks at ~16.5µs (below ECDSA).
4. **Sighash policy** — fixed `SIGHASH_ALL | FORKID`, no carried sighash byte.
5. **liboqs mandatory** — `cmake/liboqs.cmake` is a hard `FATAL_ERROR` (never a silent downgrade) plus a verified sha256 pin and a runtime `mldsa::IsAvailable()` guard in `AppInitSanityChecks`. A node that could activate ML-DSA cannot be built or started without liboqs, avoiding a consensus split.

liboqs is pinned at **0.16.0** (mldsa-native backend; proven byte-identical KeyGen vs the earlier 0.12.0 for the same seed).

## Wallet

The full PQ **spend** path works (not just receive): coin-control witness-v2 branch, correct `MaxSatisfactionWeight` for the ML-DSA descriptors, dummy-signing via `CreateMLDsa44Sig`, and `MultiSigningProvider` forwarding `HavePQKey`/`GetPQKey`. Real PQ spends confirmed on testnet across all guix targets (Linux/RISC-V/ARM/Windows/macOS) with the 0.16.0 build.

## Testing / CI

- New unit tests: `pqkey_tests` (keygen/sign/verify + KAT) and `mldsa44_sighash_tests` (real `VerifyScript`).
- `feature_mldsa44.py` extended to cover spending (single + multiple PQ inputs, PQ change, non-coinbase PQ spend).
- **CI now builds the unit-test job `WITH_LIBOQS=ON`** and runs the real ML-DSA tests (liboqs built from the pinned source in-container). All jobs green: build+unit, fuzz, lint.

## Notes for reviewers

- The consensus constants (`MLDSA44_SIGOP_COST=50`, the `.../v1` derivation and `.../v1/` context tags) are intentionally tunable while mainnet is `NEVER_ACTIVE` — feedback welcome before any activation.
- Flag renamed `SCRIPT_VERIFY_PQ_HYBRID` → `SCRIPT_VERIFY_MLDSA44` (the rule is pure ML-DSA, not hybrid).
- Deferred to later forks per the approved plan: assets+PQ, hybrid ECDSA+ML-DSA, multi-party/hardware PSBT, wallet-UX completion, and the public testnet campaign.