### PR TITLE
RIP-25 Phase 4: wallet post-quantum change routing + dead-key-path cleanup

### DIFF
--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -249,44 +249,6 @@ bool FillableSigningProvider::GetCScript(const CScriptID &hash, CScript& redeemS
     return false;
 }
 
-// RIP-25: ML-DSA-44 post-quantum key methods
-bool FillableSigningProvider::AddPQKey(CPQKey&& key)
-{
-    CPQPubKey pubkey = key.GetPubKey();
-    uint256 program = pubkey.GetWitnessProgram();
-    LOCK(cs_KeyStore);
-    mapPQPubKeys[program] = pubkey;
-    mapPQKeys[program] = std::move(key);
-    return true;
-}
-
-bool FillableSigningProvider::HavePQKey(const uint256& program) const
-{
-    LOCK(cs_KeyStore);
-    return mapPQKeys.count(program) > 0;
-}
-
-bool FillableSigningProvider::GetPQKey(const uint256& program, CPQKey& key) const
-{
-    LOCK(cs_KeyStore);
-    auto it = mapPQKeys.find(program);
-    if (it == mapPQKeys.end()) return false;
-    CPQPubKey pubkey;
-    auto pit = mapPQPubKeys.find(program);
-    if (pit != mapPQPubKeys.end()) pubkey = pit->second;
-    key.SetKeyData(it->second.GetData(), pubkey);
-    return true;
-}
-
-bool FillableSigningProvider::GetPQPubKey(const uint256& program, CPQPubKey& pubkey) const
-{
-    LOCK(cs_KeyStore);
-    auto it = mapPQPubKeys.find(program);
-    if (it == mapPQPubKeys.end()) return false;
-    pubkey = it->second;
-    return true;
-}
-
 CKeyID GetKeyForDestination(const SigningProvider& store, const CTxDestination& dest)
 {
     // Only supports destinations which map to single public keys:

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -249,8 +249,6 @@ class FillableSigningProvider : public SigningProvider
 protected:
     using KeyMap = std::map<CKeyID, CKey>;
     using ScriptMap = std::map<CScriptID, CScript>;
-    using PQKeyMap = std::map<uint256, CPQKey>;
-    using PQPubKeyMap = std::map<uint256, CPQPubKey>;
 
     /**
      * Map of key id to unencrypted private keys known by the signing provider.
@@ -301,10 +299,6 @@ protected:
      */
     ScriptMap mapScripts GUARDED_BY(cs_KeyStore);
 
-    // RIP-25: ML-DSA-44 post-quantum key storage.
-    PQKeyMap mapPQKeys GUARDED_BY(cs_KeyStore);
-    PQPubKeyMap mapPQPubKeys GUARDED_BY(cs_KeyStore);
-
     void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
 public:
@@ -320,12 +314,6 @@ public:
     virtual bool HaveCScript(const CScriptID &hash) const override;
     virtual std::set<CScriptID> GetCScripts() const;
     virtual bool GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const override;
-
-    // RIP-25: ML-DSA-44 post-quantum key management.
-    virtual bool AddPQKey(CPQKey&& key);
-    virtual bool HavePQKey(const uint256& program) const override;
-    virtual bool GetPQKey(const uint256& program, CPQKey& key) const override;
-    virtual bool GetPQPubKey(const uint256& program, CPQPubKey& pubkey) const override;
 };
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -304,28 +304,6 @@ bool LegacyDataSPKM::LoadCScript(const CScript& redeemScript)
     return FillableSigningProvider::AddCScript(redeemScript);
 }
 
-bool LegacyDataSPKM::LoadPQKey(CPQKey&& key)
-{
-    return FillableSigningProvider::AddPQKey(std::move(key));
-}
-
-util::Result<CTxDestination> LegacyDataSPKM::GenerateNewPQAddress(WalletBatch& batch)
-{
-    CPQKey pq_key;
-    if (!pq_key.MakeNewKey()) {
-        return util::Error{Untranslated("Failed to generate ML-DSA-44 key")};
-    }
-    CPQPubKey pq_pubkey = pq_key.GetPubKey();
-    if (!batch.WritePQKey(pq_pubkey, pq_key.GetData())) {
-        return util::Error{Untranslated("Failed to write PQ key to wallet database")};
-    }
-    if (!FillableSigningProvider::AddPQKey(std::move(pq_key))) {
-        return util::Error{Untranslated("Failed to add PQ key to signing provider")};
-    }
-    uint256 program = pq_pubkey.GetWitnessProgram();
-    return CTxDestination{WitnessV2MLDsa44{program}};
-}
-
 void LegacyDataSPKM::LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata& meta)
 {
     LOCK(cs_KeyStore);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -240,11 +240,6 @@ public:
     void AddInactiveHDChain(const CHDChain& chain);
     const CHDChain& GetHDChain() const { return m_hd_chain; }
 
-    //! RIP-25: Load a PQ key from wallet storage (used by LoadWallet), without saving to disk.
-    bool LoadPQKey(CPQKey&& key);
-    //! RIP-25: Generate a new ML-DSA-44 key, persist it, and return the witness v2 destination.
-    util::Result<CTxDestination> GenerateNewPQAddress(WalletBatch& batch);
-
     //! Fetches a pubkey from mapWatchKeys if it exists there
     bool GetWatchPubKey(const CKeyID &address, CPubKey &pubkey_out) const;
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -253,6 +253,8 @@ static OutputType GetOutputType(TxoutType type, bool is_from_p2sh)
     switch (type) {
         case TxoutType::WITNESS_V1_TAPROOT:
             return OutputType::BECH32M;
+        case TxoutType::WITNESS_V2_MLDSA44:
+            return OutputType::PQ; // RIP-25: post-quantum ML-DSA-44 output
         case TxoutType::WITNESS_V0_KEYHASH:
         case TxoutType::WITNESS_V0_SCRIPTHASH:
             if (is_from_p2sh) return OutputType::P2SH_SEGWIT;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2249,19 +2249,17 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
         return *change_type;
     }
 
-    // if m_default_address_type is legacy, use legacy address as change.
-    if (m_default_address_type == OutputType::LEGACY) {
-        return OutputType::LEGACY;
-    }
-
     bool any_tr{false};
     bool any_wpkh{false};
     bool any_sh{false};
     bool any_pkh{false};
+    bool any_pq{false}; // RIP-25: any ML-DSA-44 post-quantum recipient
 
     for (const auto& recipient : vecSend) {
         if (std::get_if<WitnessV1Taproot>(&recipient.dest)) {
             any_tr = true;
+        } else if (std::get_if<WitnessV2MLDsa44>(&recipient.dest)) {
+            any_pq = true;
         } else if (std::get_if<WitnessV0KeyHash>(&recipient.dest)) {
             any_wpkh = true;
         } else if (std::get_if<ScriptHash>(&recipient.dest)) {
@@ -2269,6 +2267,21 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
         } else if (std::get_if<PKHash>(&recipient.dest)) {
             any_pkh = true;
         }
+    }
+
+    // RIP-25: keep post-quantum change with a post-quantum recipient so the
+    // change output does not downgrade the spend to a quantum-vulnerable type.
+    // This deliberately takes precedence over the legacy-default rule below: a
+    // spend to a post-quantum address should not leave change in an output a
+    // quantum adversary could seize.
+    const bool has_pq_spkman(GetScriptPubKeyMan(OutputType::PQ, /*internal=*/true));
+    if (has_pq_spkman && any_pq) {
+        return OutputType::PQ;
+    }
+
+    // if m_default_address_type is legacy, use legacy address as change.
+    if (m_default_address_type == OutputType::LEGACY) {
+        return OutputType::LEGACY;
     }
 
     const bool has_bech32m_spkman(GetScriptPubKeyMan(OutputType::BECH32M, /*internal=*/true));

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -63,7 +63,6 @@ const std::string WALLETDESCRIPTORKEY{"walletdescriptorkey"};
 const std::string WALLETDESCRIPTORPQCACHE{"walletdescriptorpqcache"}; // RIP-25: ML-DSA-44 witness program cache
 const std::string WATCHMETA{"watchmeta"};
 const std::string WATCHS{"watchs"};
-const std::string PQKEY{"pqkey"}; // RIP-25: ML-DSA-44 post-quantum key
 const std::unordered_set<std::string> LEGACY_TYPES{CRYPTED_KEY, CSCRIPT, DEFAULTKEY, HDCHAIN, KEYMETA, KEY, OLD_KEY, POOL, WATCHMETA, WATCHS};
 } // namespace DBKeys
 
@@ -152,20 +151,6 @@ bool WalletBatch::WriteCryptedKey(const CPubKey& vchPubKey,
 bool WalletBatch::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 {
     return WriteIC(std::make_pair(DBKeys::MASTER_KEY, nID), kMasterKey, true);
-}
-
-bool WalletBatch::WritePQKey(const CPQPubKey& pubkey, std::span<const uint8_t, CPQKey::SIZE> secret_key)
-{
-    uint256 program = pubkey.GetWitnessProgram();
-    auto pk_data = pubkey.GetData();
-    std::vector<uint8_t> pk_vec(pk_data.begin(), pk_data.end());
-    std::vector<uint8_t> sk_vec(secret_key.begin(), secret_key.end());
-    return WriteIC(std::make_pair(DBKeys::PQKEY, program), std::make_pair(pk_vec, sk_vec), false);
-}
-
-bool WalletBatch::ErasePQKey(const uint256& program)
-{
-    return EraseIC(std::make_pair(DBKeys::PQKEY, program));
 }
 
 bool WalletBatch::EraseMasterKey(unsigned int id)
@@ -614,28 +599,6 @@ static DBErrors LoadLegacyWalletRecords(CWallet* pwallet, DatabaseBatch& batch, 
         return DBErrors::LOAD_OK;
     });
     result = std::max(result, script_res.m_result);
-
-    // Load ML-DSA-44 PQ keys (RIP-25)
-    LoadResult pqkey_res = LoadRecords(pwallet, batch, DBKeys::PQKEY,
-        [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& strErr) {
-        uint256 program;
-        key >> program;
-        std::vector<uint8_t> pk_vec, sk_vec;
-        value >> pk_vec >> sk_vec;
-        if (pk_vec.size() != CPQPubKey::SIZE || sk_vec.size() != CPQKey::SIZE) {
-            strErr = "Error reading wallet database: invalid PQ key size";
-            return DBErrors::CORRUPT;
-        }
-        CPQPubKey pq_pubkey{std::span<const uint8_t, CPQPubKey::SIZE>(pk_vec.data(), CPQPubKey::SIZE)};
-        CPQKey pq_key;
-        pq_key.SetKeyData(std::span<const uint8_t, CPQKey::SIZE>(sk_vec.data(), CPQKey::SIZE), pq_pubkey);
-        if (!pwallet->GetOrCreateLegacyDataSPKM()->LoadPQKey(std::move(pq_key))) {
-            strErr = "Error reading wallet database: LegacyDataSPKM::LoadPQKey failed";
-            return DBErrors::NONCRITICAL_ERROR;
-        }
-        return DBErrors::LOAD_OK;
-    });
-    result = std::max(result, pqkey_res.m_result);
 
     // Check whether rewrite is needed
     if (ckey_res.m_records > 0) {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -86,7 +86,6 @@ extern const std::string WALLETDESCRIPTORKEY;
 extern const std::string WALLETDESCRIPTORPQCACHE; // RIP-25: ML-DSA-44 witness program cache
 extern const std::string WATCHMETA;
 extern const std::string WATCHS;
-extern const std::string PQKEY; // RIP-25: ML-DSA-44 post-quantum key
 
 // Keys in this set pertain only to the legacy wallet (LegacyScriptPubKeyMan) and are removed during migration from legacy to descriptors.
 extern const std::unordered_set<std::string> LEGACY_TYPES;
@@ -242,9 +241,6 @@ public:
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
 
-    // RIP-25: ML-DSA-44 post-quantum key persistence.
-    bool WritePQKey(const CPQPubKey& pubkey, std::span<const uint8_t, CPQKey::SIZE> secret_key);
-    bool ErasePQKey(const uint256& program);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
     bool EraseMasterKey(unsigned int id);
 

--- a/test/functional/feature_mldsa44.py
+++ b/test/functional/feature_mldsa44.py
@@ -8,10 +8,13 @@ DEPLOYMENT_MLDSA44 is ALWAYS_ACTIVE on regtest, so these tests do not require
 any activation block logic.
 """
 
+import os
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
+    assert_raises_rpc_error,
 )
 
 # RIP-25 ML-DSA-44 witness element sizes (bytes).
@@ -156,6 +159,77 @@ class MLDsa44Test(BitcoinTestFramework):
         self.generate(node, 1)
         assert_greater_than_or_equal(node.gettransaction(res3["txid"])["confirmations"], 1)
         self.assert_pq_witness(node, res3["txid"], {(uc["txid"], uc["vout"])})
+
+        self.log.info("Test change follows a PQ recipient (RIP-25 change routing)")
+
+        # With no explicit change_type, paying a PQ recipient must keep the change
+        # in a PQ output rather than downgrading it to a quantum-vulnerable type
+        # (CWallet::TransactionChangeType). Coins are auto-selected here.
+        pq_recipient = node.getnewaddress("", "pq")
+        recipient_spk = node.getaddressinfo(pq_recipient)["scriptPubKey"]
+        change_txid = node.sendtoaddress(pq_recipient, 1.0)
+        self.generate(node, 1)
+        dec = node.decoderawtransaction(node.gettransaction(change_txid)["hex"])
+        change_types = []
+        for out in dec["vout"]:
+            spk = out["scriptPubKey"]
+            if spk["hex"] == recipient_spk:
+                continue  # this is the payment, not the change
+            addr = spk.get("address")
+            if addr and node.getaddressinfo(addr)["ismine"]:
+                change_types.append(spk.get("type"))
+        assert "witness_v2_mldsa44" in change_types, \
+            f"change should be a PQ output when paying a PQ recipient, got {change_types}"
+
+        self.log.info("Test PQ coins survive wallet backup and restore")
+
+        # Fund a fresh PQ address, back up the wallet, restore it under a new name,
+        # and spend the recovered coin. This is the "users can reliably recover PQ
+        # keys" gate: the PQ secret is derived from the (backed-up) descriptor xpriv.
+        recover_addr = node.getnewaddress("", "pq")
+        node.sendtoaddress(recover_addr, 7.0)
+        self.generate(node, 1)
+        backup_path = os.path.join(self.nodes[0].datadir_path, "pq_backup.dat")
+        node.backupwallet(backup_path)
+        node.restorewallet("pq_restored", backup_path)
+        restored = node.get_wallet_rpc("pq_restored")
+        rutxos = restored.listunspent(0, 9999999, [recover_addr])
+        assert_equal(len(rutxos), 1)
+        ru = rutxos[0]
+        rres = restored.send(
+            outputs={legacy_dest: 6.0},
+            options={"inputs": [{"txid": ru["txid"], "vout": ru["vout"]}],
+                     "add_inputs": False, "change_type": "legacy"})
+        assert_equal(rres["complete"], True)
+        self.generate(node, 1)
+        assert_greater_than_or_equal(restored.gettransaction(rres["txid"])["confirmations"], 1)
+        self.assert_pq_witness(restored, rres["txid"], {(ru["txid"], ru["vout"])})
+        node.unloadwallet("pq_restored")
+
+        self.log.info("Test a PQ spend requires an unlocked encrypted wallet")
+
+        # PQ secrets are protected transitively: they are re-derived from the
+        # encrypted descriptor xpriv, so a spend must fail while locked and succeed
+        # once the passphrase is supplied.
+        w0 = node.get_wallet_rpc(self.default_wallet_name)
+        node.createwallet(wallet_name="pq_enc")
+        enc = node.get_wallet_rpc("pq_enc")
+        enc_addr = enc.getnewaddress("", "pq")
+        w0.sendtoaddress(enc_addr, 8.0)
+        self.generate(node, 1)
+        eu = enc.listunspent(1, 9999999, [enc_addr])[0]
+        enc.encryptwallet("test-pass")
+        assert_raises_rpc_error(-13, "walletpassphrase", enc.sendtoaddress, legacy_dest, 1.0)
+        enc.walletpassphrase("test-pass", 60)
+        eres = enc.send(
+            outputs={legacy_dest: 7.0},
+            options={"inputs": [{"txid": eu["txid"], "vout": eu["vout"]}],
+                     "add_inputs": False, "change_type": "legacy"})
+        assert_equal(eres["complete"], True)
+        self.generate(node, 1)
+        assert_greater_than_or_equal(enc.gettransaction(eres["txid"])["confirmations"], 1)
+        self.assert_pq_witness(enc, eres["txid"], {(eu["txid"], eu["vout"])})
+        enc.walletlock()
 
         self.log.info("Test that 'pq' address type is rejected on non-regtest without deployment")
         # On regtest DEPLOYMENT_MLDSA44 is always active, so no negative-activation


### PR DESCRIPTION
## Summary

RIP-25 **Phase 4** (wallet completion, AVN scope). Investigating the wallet against the Phase 4 checklist showed that because the wallet is **descriptor-only** and ML-DSA-44 keys are derived deterministically from the (encrypted) descriptor xpriv rather than stored as raw secrets, most of the plan's headline items — backup/restore, keypool, rescan, encryption, import/export — are already handled by the generic descriptor machinery. The genuine remaining gaps were narrow:

**1. Change routing (`CWallet::TransactionChangeType`)**
A spend to a post-quantum recipient now keeps its change in a post-quantum output, checked *ahead* of the legacy-default rule. Avian's `DEFAULT_ADDRESS_TYPE` is `LEGACY`, so without this a PQ spend's change silently landed in a quantum-vulnerable P2PKH output — defeating the point of paying a PQ address. On mainnet the deployment is `NEVER_ACTIVE`, so no PQ recipient can arise there and change behaviour is unchanged.

**2. Coin classification (`GetOutputType` in spend.cpp)**
Witness-v2 ML-DSA coins were classified `OutputType::UNKNOWN`; they are now `OutputType::PQ`, so the wallet's own PQ coins group correctly during privacy-preserving (single-type) coin selection.

**3. Security cleanup — remove the dead unencrypted legacy key path**
`LegacyDataSPKM::GenerateNewPQAddress` had no callers, yet it was the sole writer of a `pqkey` wallet record that stored the 2560-byte ML-DSA secret key **in the clear**. Removed end to end: `GenerateNewPQAddress`/`LoadPQKey`, `WritePQKey`/`ErasePQKey` and the `pqkey` record read/write, and the now-unused `FillableSigningProvider` PQ store (`mapPQKeys`/`mapPQPubKeys` and its Add/Have/Get methods). The `SigningProvider` base virtuals, the live descriptor/`Flat`/`Multi`/`Hiding` providers, and the descriptor witness-program cache are all untouched. (`CPQKey` already secures its own memory via `secure_allocator` + `memory_cleanse`, so no in-memory change was needed.)

## Testing

Built `WITH_LIBOQS=ON` (liboqs 0.16.0), wallet enabled, and validated locally:

- **Unit** (`test_avian`): `wallet_tests`, `coinselector_tests`, `spend_tests`, `pqkey_tests`, `pqkey_vectors_tests`, `mldsa44_sighash_tests`, `mldsa44_witness_tests` — 43 cases, no errors.
- **Functional** (`feature_mldsa44.py`, extended): the existing generate/receive/spend paths plus three new Phase 4 gates, all passing:
  - change follows a PQ recipient into a witness-v2 output;
  - PQ coins survive a wallet **backup + restore** into a fresh wallet and remain spendable (the "users can reliably recover PQ keys" gate);
  - a PQ spend **fails while an encrypted wallet is locked** and succeeds once unlocked (secret protected transitively through the descriptor xpriv).

CI builds the unit job `WITH_LIBOQS=ON`, so the PQ unit suites run there; the functional suite is validated locally (not yet run in CI).